### PR TITLE
Add methods to AbstractResponder for every Payload status

### DIFF
--- a/src/Responder/AbstractResponder.php
+++ b/src/Responder/AbstractResponder.php
@@ -54,6 +54,18 @@ abstract class AbstractResponder implements ResponderInterface
         $this->responseBody($this->payload->getOutput());
     }
 
+    protected function authenticated()
+    {
+        $this->response = $this->response->withStatus(200);
+        $this->responseBody($this->payload->getOutput());
+    }
+
+    protected function authorized()
+    {
+        $this->response = $this->response->withStatus(200);
+        $this->responseBody($this->payload->getOutput());
+    }
+
     protected function created()
     {
         $this->response = $this->response->withStatus(201);
@@ -92,6 +104,12 @@ abstract class AbstractResponder implements ResponderInterface
         $this->response = $this->response->withStatus(204);
     }
 
+    protected function notAccepted()
+    {
+        $this->response = $this->response->withStatus(406);
+        $this->responseBody($this->payload->getInput());
+    }
+
     protected function notAuthenticated()
     {
         $this->response = $this->response->withStatus(400);
@@ -104,9 +122,27 @@ abstract class AbstractResponder implements ResponderInterface
         $this->responseBody($this->payload->getInput());
     }
 
+    protected function notCreated()
+    {
+        $this->response = $this->response->withStatus(400);
+        $this->responseBody($this->payload->getInput());
+    }
+
+    protected function notDeleted()
+    {
+        $this->response = $this->response->withStatus(400);
+        $this->responseBody($this->payload->getInput());
+    }
+
     protected function notFound()
     {
         $this->response = $this->response->withStatus(404);
+        $this->responseBody($this->payload->getInput());
+    }
+
+    protected function notUpdated()
+    {
+        $this->response = $this->response->withStatus(400);
         $this->responseBody($this->payload->getInput());
     }
 
@@ -122,11 +158,23 @@ abstract class AbstractResponder implements ResponderInterface
 
     protected function processing()
     {
-        $this->response = $this->response->withStatus(203);
+        $this->response = $this->response->withStatus(202);
         $this->responseBody($this->payload->getOutput());
     }
 
     protected function success()
+    {
+        $this->response = $this->response->withStatus(200);
+        $this->responseBody($this->payload->getOutput());
+    }
+
+    protected function updated()
+    {
+        $this->response = $this->response->withStatus(303);
+        $this->responseBody($this->payload->getOutput());
+    }
+
+    protected function valid()
     {
         $this->response = $this->response->withStatus(200);
         $this->responseBody($this->payload->getOutput());
@@ -139,11 +187,5 @@ abstract class AbstractResponder implements ResponderInterface
             'error' => 'Unknown domain payload status',
             'status' => $this->payload->getStatus(),
         ]);
-    }
-
-    protected function updated()
-    {
-        $this->response = $this->response->withStatus(303);
-        $this->responseBody($this->payload->getOutput());
     }
 }

--- a/tests/Responder/AbstractResponderTest.php
+++ b/tests/Responder/AbstractResponderTest.php
@@ -21,18 +21,25 @@ class AbstractResponderTest extends TestCase {
             ['unknown', 500],
             [null, 204],
             [Payload::ACCEPTED, 202],
+            [Payload::AUTHENTICATED, 200],
+            [Payload::AUTHORIZED, 200],
             [Payload::CREATED, 201],
             [Payload::DELETED, 204],
             [Payload::ERROR, 500],
             [Payload::FAILURE, 400],
             [Payload::FOUND, 200],
+            [Payload::NOT_ACCEPTED, 406],
             [Payload::NOT_AUTHENTICATED, 400],
             [Payload::NOT_AUTHORIZED, 403],
+            [Payload::NOT_CREATED, 400],
+            [Payload::NOT_DELETED, 400],
             [Payload::NOT_FOUND, 404],
+            [Payload::NOT_UPDATED, 400],
             [Payload::NOT_VALID, 422],
-            [Payload::PROCESSING, 203],
+            [Payload::PROCESSING, 202],
             [Payload::SUCCESS, 200],
             [Payload::UPDATED, 303],
+            [Payload::VALID, 200]
         ];
     }
 


### PR DESCRIPTION
Also changed the status code for processing() from 203 to 202, because per the HTTP spec, 202 means "The request has been accepted for processing, but the processing has not been completed."

I would appreciate it if you guys would look at the HTTP status codes I chose for the new methods. I did my best to choose statuses that fit, but there wasn't always a good match.