### PR TITLE
Removed unused use directives from HtmlResponder and JsonResponder

### DIFF
--- a/src/Responder/HtmlResponder.php
+++ b/src/Responder/HtmlResponder.php
@@ -1,11 +1,6 @@
 <?php
 namespace Spark\Responder;
 
-use Aura\Payload_Interface\PayloadInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use Spark\Adr\ResponderInterface;
-
 class HtmlResponder extends AbstractResponder
 {
 

--- a/src/Responder/JsonResponder.php
+++ b/src/Responder/JsonResponder.php
@@ -1,11 +1,6 @@
 <?php
 namespace Spark\Responder;
 
-use Aura\Payload_Interface\PayloadInterface;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use Spark\Adr\ResponderInterface;
-
 class JsonResponder extends AbstractResponder
 {
     


### PR DESCRIPTION
The `use` directives at the top of `HtmlResponder` and `JsonResponder` were likely copied from `AbstractResponder` and left in even though they aren't needed.