### PR TITLE
Change error() to use messages instead of output

### DIFF
--- a/src/Responder/AbstractResponder.php
+++ b/src/Responder/AbstractResponder.php
@@ -83,7 +83,7 @@ abstract class AbstractResponder implements ResponderInterface
         $this->response = $this->response->withStatus(500);
         $this->responseBody([
             'input' => $this->payload->getInput(),
-            'error' => $this->payload->getOutput(),
+            'error' => $this->payload->getMessages(),
         ]);
     }
 


### PR DESCRIPTION
In practice, I think it makes more sense for the error() method in AbstractResponder to have its "error" information based on the payload's messages rather than its output. I'm curious if you guys agree.