### PR TITLE
Make dotenv a suggested package instead of a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "php": ">=5.5.0",
         "aura/payload": "3.*@dev",
-        "josegonzalez/dotenv": "~0.7",
         "monolog/monolog": "~1.13",
         "nikic/fast-route": "0.4.*",
         "rdlowrey/auryn": "0.15.*",
@@ -19,6 +18,9 @@
     "require-dev": {
         "phpunit/phpunit": "~4.6",
         "satooshi/php-coveralls": "0.6.1"
+    },
+    "suggest": {
+        "josegonzalez/dotenv": "For environment based configuration loading"
     },
     "autoload": {
         "psr-4": {

--- a/src/Application.php
+++ b/src/Application.php
@@ -49,10 +49,6 @@ class Application
             'Spark\Resolver'
         );
 
-        $loader = $injector->make('josegonzalez\Dotenv\Loader', [':filepaths' => APP_PATH . '.env']);
-        $loader->parse();
-        $loader->toEnv(true);
-
         return $injector->make(static::class);
     }
 


### PR DESCRIPTION
ENV handling should be done at the user level, not forced by the framework.