### PR TITLE
Refactor resolvers to use an interface

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -42,8 +42,8 @@ class Application
 
         // By default, we use our internal Resolver
         $injector->alias(
-            'Resolver',
-            'Spark\Resolver'
+            'Spark\Resolver\ResolverInterface',
+            'Spark\Resolver\AurynResolver'
         );
 
         return $injector->make(static::class);
@@ -104,7 +104,7 @@ class Application
      */
     public function getResolver()
     {
-        return $this->injector->make('Resolver');
+        return $this->injector->make('Spark\Resolver\ResolverInterface');
     }
 
     /**

--- a/src/Handler/ActionHandler.php
+++ b/src/Handler/ActionHandler.php
@@ -10,18 +10,18 @@ use Psr\Http\Message\ResponseInterface;
 use Spark\Adr\DomainInterface;
 use Spark\Adr\InputInterface;
 use Spark\Adr\ResponderInterface;
-use Spark\Resolver;
+use Spark\Resolver\ResolverInterface;
 
 class ActionHandler extends Arbiter
 {
     /**
-     * @var Resolver
+     * @var Spark\Resolver\ResolverInterface
      */
     protected $resolver;
 
     protected $actionAttribute = 'spark/adr:action';
 
-    public function __construct(Resolver $resolver)
+    public function __construct(ResolverInterface $resolver)
     {
         $this->resolver = $resolver;
     }

--- a/src/Resolver/AurynResolver.php
+++ b/src/Resolver/AurynResolver.php
@@ -12,11 +12,15 @@ class AurynResolver implements ResolverInterface
         $this->injector = $injector;
     }
 
+    /**
+     * Returns an instance of a specified class implementing __invoke() using
+     * the underlying Auryn injector.
+     *
+     * @param string $fqcn Fully-qualified class name
+     * @return callable Instance of the referenced class
+     */
     public function __invoke($spec)
     {
-        if (is_callable($spec)) {
-            return $spec;
-        }
         return $this->injector->make($spec);
     }
 }

--- a/src/Resolver/AurynResolver.php
+++ b/src/Resolver/AurynResolver.php
@@ -1,9 +1,9 @@
 <?php
-namespace Spark;
+namespace Spark\Resolver;
 
 use Auryn\Injector;
 
-class Resolver
+class AurynResolver implements ResolverInterface
 {
     protected $injector;
 

--- a/src/Resolver/AurynResolver.php
+++ b/src/Resolver/AurynResolver.php
@@ -16,7 +16,7 @@ class AurynResolver implements ResolverInterface
      * Returns an instance of a specified class implementing __invoke() using
      * the underlying Auryn injector.
      *
-     * @param string $fqcn Fully-qualified class name
+     * @param string $spec Fully-qualified class name
      * @return callable Instance of the referenced class
      */
     public function __invoke($spec)

--- a/src/Resolver/ResolverInterface.php
+++ b/src/Resolver/ResolverInterface.php
@@ -1,0 +1,11 @@
+<?php
+namespace Spark\Resolver;
+
+interface ResolverInterface
+{
+    /**
+     * @param mixed $spec
+     * @return callable
+     */
+    public function __invoke($spec);
+}

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -119,9 +119,6 @@ class ApplicationTest extends TestCase
         $name = 'SparkTests\Fake\FakeDomain';
         $fakeDomain = $resolver($name);
         $this->assertInstanceOf($name, $fakeDomain);
-
-        $resolvedFakeDomain = $resolver($fakeDomain);
-        $this->assertEquals($fakeDomain, $resolvedFakeDomain);
     }
 
 

--- a/tests/Handler/ActionHandlerTest.php
+++ b/tests/Handler/ActionHandlerTest.php
@@ -4,6 +4,7 @@ namespace SparkTests\Handler;
 use Arbiter\Action;
 use Auryn\Injector;
 use PHPUnit_Framework_TestCase as TestCase;
+use Spark\Resolver\AurynResolver;
 use Spark\Router\Route;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequestFactory;
@@ -44,6 +45,7 @@ class ActionHandlerTest extends TestCase
         $request = $request->withAttribute('spark/adr:action', $action)
                         ->withAttribute('test', 'success');
 
+        $injector->alias('Spark\Resolver\ResolverInterface', 'Spark\Resolver\AurynResolver');
         $actionHandler = $injector->make('Spark\Handler\ActionHandler');
 
         $response = $actionHandler($request, $response, function($req, $resp) {


### PR DESCRIPTION
* `Spark\Resolver\ResolverInterface` is now used for typehinting resolvers
* `Spark\Resolver` is now `Spark\Resolver\AurynResolver`
* `Spark\Resolver\AurynResolver->__invoke()` no longer supports `callable` `$spec` values since that's not a feature we presently use and isn't really tied to the use of Auryn in any way