### PR TITLE
Add support for injector configurations

### DIFF
--- a/src/Configuration/AurynConfiguration.php
+++ b/src/Configuration/AurynConfiguration.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Spark\Configuration;
+
+use Auryn\Injector;
+
+class AurynConfiguration implements ConfigurationInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function apply(Injector $injector)
+    {
+        $injector->share($injector);
+
+        $injector->alias(
+            'Spark\Resolver\ResolverInterface',
+            'Spark\Resolver\AurynResolver'
+        );
+    }
+}

--- a/src/Configuration/ConfigurationInterface.php
+++ b/src/Configuration/ConfigurationInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spark\Configuration;
+
+use Auryn\Injector;
+
+interface ConfigurationInterface
+{
+    /**
+     * Applies a configuration set to a dependency injector.
+     *
+     * @param Injector $injector
+     */
+    public function apply(Injector $injector);
+}

--- a/src/Configuration/ConfigurationSet.php
+++ b/src/Configuration/ConfigurationSet.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Spark\Configuration;
+
+use Auryn\Injector;
+
+class ConfigurationSet implements ConfigurationInterface
+{
+    /**
+     * @var array
+     */
+    protected $classes;
+
+    /**
+     * @param array $classes
+     */
+    public function __construct(array $classes)
+    {
+        $this->validateClasses($classes);
+
+        $this->classes = $classes;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function apply(Injector $injector)
+    {
+        foreach ($this->classes as $class) {
+            $configuration = $injector->make($class);
+            $configuration->apply($injector);
+        }
+    }
+
+    /**
+     * @param array $classes
+     * @throws \DomainException if any classes cannot be loaded
+     */
+    protected function validateClasses(array $classes)
+    {
+        $invalid = array_filter(
+            $classes,
+            function ($class) {
+                return !is_subclass_of($class, ConfigurationInterface::class);
+            }
+        );
+        if ($invalid) {
+            $message = 'Classes cannot be loaded or do not implement ConfigurationInterface: ' . implode(', ', $invalid);
+            throw new \DomainException($message);
+        }
+    }
+}

--- a/src/Configuration/DefaultConfigurationSet.php
+++ b/src/Configuration/DefaultConfigurationSet.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spark\Configuration;
+
+class DefaultConfigurationSet extends ConfigurationSet
+{
+    public function __construct()
+    {
+        parent::__construct([
+            AurynConfiguration::class,
+            DiactorosConfiguration::class,
+            NegotiationConfiguration::class,
+            RelayConfiguration::class,
+        ]);
+    }
+}

--- a/src/Configuration/DiactorosConfiguration.php
+++ b/src/Configuration/DiactorosConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Spark\Configuration;
+
+use Auryn\Injector;
+
+class DiactorosConfiguration implements ConfigurationInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function apply(Injector $injector)
+    {
+        $injector->alias(
+            'Psr\Http\Message\ResponseInterface',
+            'Zend\Diactoros\Response'
+        );
+
+        $injector->delegate(
+            'Psr\Http\Message\ServerRequestInterface',
+            'Zend\Diactoros\ServerRequestFactory::fromGlobals'
+        );
+    }
+}

--- a/src/Configuration/NegotiationConfiguration.php
+++ b/src/Configuration/NegotiationConfiguration.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spark\Configuration;
+
+use Auryn\Injector;
+
+class NegotiationConfiguration implements ConfigurationInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function apply(Injector $injector)
+    {
+        $injector->alias(
+            'Negotiation\NegotiatorInterface',
+            'Negotiation\Negotiator'
+        );
+    }
+}

--- a/src/Configuration/RelayConfiguration.php
+++ b/src/Configuration/RelayConfiguration.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spark\Configuration;
+
+use Auryn\Injector;
+
+class RelayConfiguration implements ConfigurationInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function apply(Injector $injector)
+    {
+        $injector->alias(
+            'Relay',
+            'Relay\RelayBuilder'
+        );
+    }
+}

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -4,6 +4,7 @@ namespace SparkTests;
 use Auryn\Injector;
 use PHPUnit_Framework_TestCase as TestCase;
 use Spark\Application;
+use Spark\Configuration\DefaultConfigurationSet;
 use Spark\Router;
 use SparkTests\Fake\FakeDomain;
 use Zend\Diactoros\Response;
@@ -13,14 +14,27 @@ use Zend\Diactoros\Uri;
 class ApplicationTest extends TestCase
 {
     /**
-     * @var $app Application
+     * @var Application
      */
     protected $app;
 
+    /**
+     * @var Injector
+     */
+    protected $injector;
+
+    /**
+     * @var Router
+     */
+    protected $router;
+
     public function setUp()
     {
-        $this->app = Application::boot();
-
+        $this->injector = new Injector;
+        $configuration = new DefaultConfigurationSet;
+        $configuration->apply($this->injector);
+        $this->router = new Router;
+        $this->app = new Application($this->injector, $this->router);
         $this->app->setMiddleware([
             'Relay\Middleware\ResponseSender',
             'Spark\Handler\RouteHandler',
@@ -28,17 +42,8 @@ class ApplicationTest extends TestCase
         ]);
     }
 
-    public function testBoot()
-    {
-        $this->assertTrue($this->app instanceof Application);
-        $this->assertTrue($this->app->getInjector() instanceof Injector);
-        $this->assertTrue($this->app->getRouter() instanceof Router);
-
-    }
-
     public function testHandleArguments()
     {
-
         $this->app->setMiddleware([
             'Spark\Handler\RouteHandler',
             'Spark\Handler\ActionHandler',
@@ -93,15 +98,4 @@ class ApplicationTest extends TestCase
         $this->assertCount(4, $this->app->getMiddleware());
         $this->assertEquals('Spark\Handler\ExceptionHandler', $this->app->getMiddleware()[3]);
     }
-
-    public function testGetResolver()
-    {
-        $resolver = $this->app->getResolver();
-
-        $name = 'SparkTests\Fake\FakeDomain';
-        $fakeDomain = $resolver($name);
-        $this->assertInstanceOf($name, $fakeDomain);
-    }
-
-
 }

--- a/tests/Handler/RouteHandlerTest.php
+++ b/tests/Handler/RouteHandlerTest.php
@@ -2,7 +2,6 @@
 namespace SparkTests\Handler;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use Spark\Application;
 use Spark\Exception\HttpMethodNotAllowed;
 use Spark\Handler\RouteHandler;
 use Spark\Router;
@@ -27,8 +26,7 @@ class RouteHandlerTest extends TestCase
     public function testDispatching()
     {
         $methods = $this->routeMethodProvider();
-        $app = Application::boot();
-        $router = $app->getRouter();
+        $router = new Router;
 
         $routeHandler = new RouteHandler($router);
 

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -3,7 +3,6 @@ namespace SparkTests;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use Spark\Adr\Input;
-use Spark\Application;
 use Spark\Router;
 use SparkTests\Fake\FakeInput;
 use Zend\Diactoros\ServerRequest;
@@ -11,16 +10,24 @@ use Zend\Diactoros\Uri;
 
 class RouterTest extends TestCase
 {
+    /**
+     * @var Router
+     */
+    protected $router;
+
+    protected function setUp()
+    {
+        $this->router = new Router;
+    }
+
     public function testRouterDispatchAndInjection()
     {
-        $app = Application::boot();
-        $router = $app->getRouter();
-        $router->get('/', 'SparkTests\Fake\FakeDomain');
+        $this->router->get('/', 'SparkTests\Fake\FakeDomain');
 
         /**
          * @var $route Router\Route
          */
-        $route = current($router->getRoutes());
+        $route = current($this->router->getRoutes());
         $this->assertInstanceOf('\Spark\Router\Route', $route);
         $this->assertEquals('Spark\Responder\ChainedResponder', $route->getResponder());
         $this->assertEquals('Spark\Adr\Input', $route->getInput());
@@ -43,16 +50,12 @@ class RouterTest extends TestCase
 
     public function testRouteDefaults()
     {
-        $app = Application::boot();
-
-        $router = $app->getRouter();
-
         $input = 'SparkTest\Fake\FakeInput';
-        $router->setDefaultInput($input);
+        $this->router->setDefaultInput($input);
         $responder = 'SparkTest\Fake\FakeResponder';
-        $router->setDefaultResponder($responder);
+        $this->router->setDefaultResponder($responder);
 
-        $route = $router->get('/', 'SparkTest\Fake\FakeDomain');
+        $route = $this->router->get('/', 'SparkTest\Fake\FakeDomain');
 
         $this->assertEquals($input, $route->getInput());
         $this->assertEquals($responder, $route->getResponder());
@@ -77,8 +80,7 @@ class RouterTest extends TestCase
      */
     public function testRoutes($method)
     {
-        $router = Application::boot()->getRouter();
-        $route = $router->$method('/test', '\SparkTests\Fake\FakeDomain');
+        $route = $this->router->$method('/test', '\SparkTests\Fake\FakeDomain');
 
         $this->assertInstanceOf('Spark\Router\Route', $route);
     }


### PR DESCRIPTION
**DO NOT MERGE THIS YET**. It will require a corresponding PR in [sparkphp/project](https://github.com/sparkphp/project) to make corresponding changes to the [application bootstrap file](https://github.com/sparkphp/project/blob/master/web/index.php) to avoid breaking things.

* Add `Configuration` subnamespace with `ConfigurationInterface` for
  implementing individual injector configurations
* Remove `Application::boot()` and move its contents into classes
  under the `Configuration` subnamespace
* Remove `Application->getInjector()`, `getResolver()`, and
  `getRouter()`, as these unnecessarily expose inner workings of the
  class

Fixes #35.