### PR TITLE
Enable ignoring docs in composer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,5 @@
 /phpunit.xml.dist   export-ignore
 /phpunit.php        export-ignore
 /tests              export-ignore
+/docs               export-ignore
+/mkdocs.yml         export-ignore


### PR DESCRIPTION
Very minor change, but no reason to litter people's vendor directory.