### PR TITLE
Modify Application to not use a service locator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "arbiter/arbiter": "~0.1",
         "nikic/fast-route": "~0.6",
         "rdlowrey/auryn": "~1.0",
-        "relay/relay": "~0.2",
+        "relay/relay": "^1",
         "relay/middleware": "~0.1",
         "sparkphp/adr": "~0.2",
         "willdurand/negotiation": "~1.4",

--- a/src/Configuration/RelayConfiguration.php
+++ b/src/Configuration/RelayConfiguration.php
@@ -3,6 +3,8 @@
 namespace Spark\Configuration;
 
 use Auryn\Injector;
+use Relay\RelayBuilder;
+use Spark\Middleware\Collection as MiddlewareCollection;
 
 class RelayConfiguration implements ConfigurationInterface
 {
@@ -11,9 +13,18 @@ class RelayConfiguration implements ConfigurationInterface
      */
     public function apply(Injector $injector)
     {
-        $injector->alias(
-            'Relay',
-            'Relay\RelayBuilder'
+        $injector->define(
+            RelayBuilder::class,
+            [
+                'resolver' => 'Spark\Resolver\ResolverInterface',
+            ]
+        );
+
+        $injector->delegate(
+            'Relay\\Relay',
+            function (RelayBuilder $builder, MiddlewareCollection $queue) {
+                return $builder->newInstance($queue);
+            }
         );
     }
 }

--- a/src/Middleware/Collection.php
+++ b/src/Middleware/Collection.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Spark\Middleware;
+
+use Relay\MiddlewareInterface;
+
+class Collection extends \ArrayObject
+{
+    /**
+     * @param array|Traversable $middlewares
+     */
+    public function __construct($middlewares)
+    {
+        $this->validate($middlewares);
+
+        parent::__construct($middlewares);
+    }
+
+    /**
+     * @param array|Traversable $middlewares
+     * @throws \DomainException if $middlewares does not conform to type expectations
+     */
+    protected function validate($middlewares)
+    {
+        if (!(is_array($middlewares) || $middlewares instanceof \Traversable)) {
+            throw new \DomainException('$middlewares must be an array or implement Traversable');
+        }
+
+        foreach ($middlewares as $middleware) {
+            if (!(is_callable($middleware) || $middleware instanceof MiddlewareInterface)) {
+                throw new \DomainException(
+                    'All elements of $middlewares must be callable or implement Relay\\MiddlewareInterface'
+                );
+            }
+        }
+    }
+}

--- a/src/Middleware/DefaultCollection.php
+++ b/src/Middleware/DefaultCollection.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spark\Configuration;
+
+use Relay\Middleware\ResponseSender;
+use Spark\Handler\ContentHandler;
+use Spark\Handler\ExceptionHandler;
+use Spark\Handler\RouteHandler;
+
+class DefaultCollection extends MiddlewareCollection
+{
+    public function __construct()
+    {
+        parent::__construct([
+            ResponseSender::class,
+            ExceptionHandler::class,
+            RouteHandler::class,
+            ContentHandler::class,
+            ActionHandler::class,
+        ]);
+    }
+}

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -1,101 +1,62 @@
 <?php
 namespace SparkTests;
 
-use Auryn\Injector;
 use PHPUnit_Framework_TestCase as TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Relay\Relay;
 use Spark\Application;
-use Spark\Configuration\DefaultConfigurationSet;
-use Spark\Router;
-use SparkTests\Fake\FakeDomain;
-use Zend\Diactoros\Response;
-use Zend\Diactoros\ServerRequestFactory;
-use Zend\Diactoros\Uri;
 
 class ApplicationTest extends TestCase
 {
+    /**
+     * @var Relay
+     */
+    protected $dispatcher;
+
+    /**
+     * @var ServerRequestInterface
+     */
+    protected $request;
+
+    /**
+     * @var ResponseInterface
+     */
+    protected $response;
+
     /**
      * @var Application
      */
     protected $app;
 
-    /**
-     * @var Injector
-     */
-    protected $injector;
-
-    /**
-     * @var Router
-     */
-    protected $router;
-
     public function setUp()
     {
-        $this->injector = new Injector;
-        $configuration = new DefaultConfigurationSet;
-        $configuration->apply($this->injector);
-        $this->router = new Router;
-        $this->app = new Application($this->injector, $this->router);
-        $this->app->setMiddleware([
-            'Relay\Middleware\ResponseSender',
-            'Spark\Handler\RouteHandler',
-            'Spark\Handler\ActionHandler',
-        ]);
+        $this->dispatcher = $this->getMockBuilder(Relay::class)->disableOriginalConstructor()->getMock();
+        $this->request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+        $this->response = $this->getMockBuilder(ResponseInterface::class)->getMock();
+        $this->app = new Application($this->dispatcher, $this->request, $this->response);
     }
 
-    public function testHandleArguments()
+    public function testHandle()
     {
-        $this->app->setMiddleware([
-            'Spark\Handler\RouteHandler',
-            'Spark\Handler\ActionHandler',
-        ]);
+        $this->dispatcher
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->request, $this->response);
 
-        $request = ServerRequestFactory::fromGlobals()
-            ->withUri(new Uri('/testing-is-fun'));
-        $response = new Response();
-
-        $this->app->addRoutes(function(Router $router) {
-            $router->get('/{arg}', '\SparkTests\Fake\FakeDomain');
-        });
-
-        $handledResponse = $this->app->handle($request, $response);
-        $this->assertInstanceOf('\Zend\Diactoros\Response', $handledResponse);
-
-        $body = json_decode($handledResponse->getBody());
-        $this->assertEquals('testing-is-fun', $body->input->arg);
+        $this->app->handle();
     }
 
-    /**
-     * @expectedException \Spark\Exception\HttpNotFound
-     */
-    public function testHandleException()
-    {
-        $request = ServerRequestFactory::fromGlobals();
-        $response = new Response();
-
-        $this->app->handle($request, $response, false);
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
     public function testRun()
     {
-        $this->app->addRoutes(function(Router $router) {
-            $router->get('/', '\SparkTests\Fake\FakeDomain');
-        });
+        $this->expectOutputString('output');
+
+        $this->dispatcher
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->request, $this->response)
+            ->will($this->returnCallback(function() { echo 'output'; }));
 
         $this->app->run();
-
-        $this->expectOutputString('{"success":true,"input":[]}');
-    }
-
-    public function testAddMiddleware()
-    {
-        $this->assertCount(3, $this->app->getMiddleware());
-
-        $this->app->addMiddleware('Spark\Handler\ExceptionHandler');
-
-        $this->assertCount(4, $this->app->getMiddleware());
-        $this->assertEquals('Spark\Handler\ExceptionHandler', $this->app->getMiddleware()[3]);
     }
 }

--- a/tests/Configuration/RelayConfigurationTest.php
+++ b/tests/Configuration/RelayConfigurationTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace SparkTests\Configuration;
+
+use Auryn\Injector;
+use PHPUnit_Framework_TestCase as TestCase;
+use Relay\MiddlewareInterface;
+use Relay\Relay;
+use Spark\Configuration\AurynConfiguration;
+use Spark\Configuration\RelayConfiguration;
+use Spark\Middleware\Collection as MiddlewareCollection;
+
+class RelayConfigurationTestCase extends TestCase
+{
+    public function testApply()
+    {
+        $injector = new Injector;
+
+        $auryn = new AurynConfiguration;
+        $auryn->apply($injector);
+
+        $relay = new RelayConfiguration;
+        $relay->apply($injector);
+
+        $middleware = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
+        $injector->define(MiddlewareCollection::class, [':middlewares' => [$middleware]]);
+
+        $dispatcher = $injector->make(Relay::class);
+
+        $this->assertInstanceOf(Relay::class, $dispatcher);
+    }
+}

--- a/tests/Middleware/CollectionTest.php
+++ b/tests/Middleware/CollectionTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace SparkTests\Middleware;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Spark\Middleware\Collection as MiddlewareCollection;
+
+class MiddlewareCollectionTest extends TestCase
+{
+    /**
+     * @param mixed $middlewares
+     * @param string $message
+     * @dataProvider dataInvalidEntries
+     */
+    public function testWithInvalidEntries($middlewares, $message)
+    {
+        $this->setExpectedException(
+            '\\DomainException',
+            $message
+        );
+
+        $collection = new MiddlewareCollection($middlewares);
+    }
+
+    /**
+     * @return array
+     */
+    public function dataInvalidEntries()
+    {
+        $data = [];
+        $middlewares = '$middlewares must be an array or implement Traversable';
+        $elements = 'All elements of $middlewares must be callable or implement Relay\\MiddlewareInterface';
+
+        $data[] = ['foo', $middlewares];
+        $data[] = [['foo'], $elements];
+        $data[] = [new \ArrayObject(['foo']), $elements];
+
+        return $data;
+    }
+
+    public function testWithValidEntries()
+    {
+        $callback = function() { };
+        $middlewares = [$callback];
+        $collection = new MiddlewareCollection($middlewares);
+        foreach ($collection as $actual) {
+            $this->assertSame($callback, $actual);
+        }
+    }
+}


### PR DESCRIPTION
* Removed the Auryn injector dependency from the `Application` class
* Added a `Middleware` subnamespace with a `Collection` class for
  encapsulating the middleware list used by Relay and a
  `DefaultCollection` for middlewares used by the Spark core
* Relocated Relay dispatcher configuration to the
  `RelayConfiguration` class
* Upgraded Relay to 1.0, which adds a middleware interface usable
  for validating references to middleware classes

Fixes #42