### PR TITLE
Remove HtmlFormatter->body() implementation

### DIFF
--- a/src/Formatter/HtmlFormatter.php
+++ b/src/Formatter/HtmlFormatter.php
@@ -4,7 +4,7 @@ namespace Spark\Formatter;
 
 use Spark\Adr\PayloadInterface;
 
-class HtmlFormatter extends AbstractFormatter
+abstract class HtmlFormatter extends AbstractFormatter
 {
     public static function accepts()
     {
@@ -14,10 +14,5 @@ class HtmlFormatter extends AbstractFormatter
     public function type()
     {
         return 'text/html';
-    }
-
-    public function body(PayloadInterface $payload)
-    {
-        return implode("\n", $payload->getOutput());
     }
 }

--- a/src/Responder/FormattedResponder.php
+++ b/src/Responder/FormattedResponder.php
@@ -27,7 +27,6 @@ class FormattedResponder implements ResponderInterface
      */
     private $formatters = [
         'Spark\Formatter\JsonFormatter' => 1.0,
-        'Spark\Formatter\PlatesFormatter' => 0.9,
     ];
 
     /**

--- a/src/Responder/FormattedResponder.php
+++ b/src/Responder/FormattedResponder.php
@@ -27,7 +27,7 @@ class FormattedResponder implements ResponderInterface
      */
     private $formatters = [
         'Spark\Formatter\JsonFormatter' => 1.0,
-        'Spark\Formatter\HtmlFormatter' => 0.9,
+        'Spark\Formatter\PlatesFormatter' => 0.9,
     ];
 
     /**

--- a/tests/Formatter/HtmlFormatterTest.php
+++ b/tests/Formatter/HtmlFormatterTest.php
@@ -14,19 +14,7 @@ class HtmlFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function testType()
     {
-        $this->assertEquals('text/html', (new HtmlFormatter)->type());
-    }
-
-    public function testBody()
-    {
-        $payload = (new Payload)->withOutput([
-            'header' => 'header',
-            'body'   => 'body',
-            'footer' => 'footer',
-        ]);
-
-        $body = (new HtmlFormatter)->body($payload);
-
-        $this->assertEquals("header\nbody\nfooter", $body);
+        $formatter = $this->getMockForAbstractClass(HtmlFormatter::class);
+        $this->assertEquals('text/html', $formatter->type());
     }
 }

--- a/tests/Responder/FormattedResponderTest.php
+++ b/tests/Responder/FormattedResponderTest.php
@@ -30,7 +30,6 @@ class FormattedResponderTest extends \PHPUnit_Framework_TestCase
         $formatters = $this->responder->getFormatters();
 
         $this->assertArrayHasKey('Spark\Formatter\JsonFormatter', $formatters);
-        $this->assertArrayHasKey('Spark\Formatter\PlatesFormatter', $formatters);
 
         unset($formatters['Spark\Formatter\JsonFormatter']);
 

--- a/tests/Responder/FormattedResponderTest.php
+++ b/tests/Responder/FormattedResponderTest.php
@@ -2,7 +2,6 @@
 
 namespace SparkTests\Responder;
 
-use Spark\Formatter\HtmlFormatter;
 use Spark\Payload;
 use Spark\Responder\FormattedResponder;
 
@@ -31,7 +30,7 @@ class FormattedResponderTest extends \PHPUnit_Framework_TestCase
         $formatters = $this->responder->getFormatters();
 
         $this->assertArrayHasKey('Spark\Formatter\JsonFormatter', $formatters);
-        $this->assertArrayHasKey('Spark\Formatter\HtmlFormatter', $formatters);
+        $this->assertArrayHasKey('Spark\Formatter\PlatesFormatter', $formatters);
 
         unset($formatters['Spark\Formatter\JsonFormatter']);
 
@@ -56,7 +55,7 @@ class FormattedResponderTest extends \PHPUnit_Framework_TestCase
         $request = $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->getMock();
         $request->method('getHeader')
                 ->with('Accept')
-                ->willReturn(['text/html']);
+                ->willReturn(['application/json']);
 
         $response = new Response;
         $payload  = (new Payload)
@@ -67,7 +66,7 @@ class FormattedResponderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
         $this->assertEquals(200, $response->getStatusCode());
-        $this->assertEquals(['text/html'], $response->getHeader('Content-Type'));
-        $this->assertEquals('test', (string) $response->getBody());
+        $this->assertEquals(['application/json'], $response->getHeader('Content-Type'));
+        $this->assertEquals('{"test":"test"}', (string) $response->getBody());
     }
 }


### PR DESCRIPTION
Per discussion on Hipchat, it makes more sense to not implement `body()` in `HtmlFormatter` and to require subclasses, such as `PlatesFormatter`, to implement it instead.