### PR TITLE
Relax validation in Middleware\Collection

### DIFF
--- a/src/Middleware/Collection.php
+++ b/src/Middleware/Collection.php
@@ -23,9 +23,9 @@ class Collection extends \ArrayObject
     protected function validate(array $middlewares)
     {
         foreach ($middlewares as $middleware) {
-            if (!(is_callable($middleware) || is_subclass_of($middleware, MiddlewareInterface::class))) {
+            if (!(is_callable($middleware) || method_exists($middleware, '__invoke'))) {
                 throw new \DomainException(
-                    'All elements of $middlewares must be callable or implement Relay\\MiddlewareInterface'
+                    'All elements of $middlewares must be callable or implement __invoke()'
                 );
             }
         }

--- a/tests/Middleware/CollectionTest.php
+++ b/tests/Middleware/CollectionTest.php
@@ -15,7 +15,7 @@ class MiddlewareCollectionTest extends TestCase
     {
         $this->setExpectedException(
             '\\DomainException',
-            'All elements of $middlewares must be callable or implement Relay\\MiddlewareInterface'
+            'All elements of $middlewares must be callable or implement __invoke()'
         );
 
         $middlewares = ['foo'];


### PR DESCRIPTION
This is intended to be a temporary measure to allow [middlewares included in `Middleware\DefaultCollection`](https://github.com/sparkphp/spark/blob/40ab5f1aded4290b4851e3c22c5ef392363b4e66/src/Middleware/DefaultCollection.php#L17-L22) to be considered valid until such time as they implement `Relay\MiddlewareInterface`.

Refs #50