### PR TITLE
Add PayloadConfiguration to DefaultConfigurationSet

### DIFF
--- a/src/Configuration/DefaultConfigurationSet.php
+++ b/src/Configuration/DefaultConfigurationSet.php
@@ -10,6 +10,7 @@ class DefaultConfigurationSet extends ConfigurationSet
             AurynConfiguration::class,
             DiactorosConfiguration::class,
             NegotiationConfiguration::class,
+            PayloadConfiguration::class,
             RelayConfiguration::class,
         ]);
     }

--- a/src/Configuration/PayloadConfiguration.php
+++ b/src/Configuration/PayloadConfiguration.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spark\Configuration;
+
+use Auryn\Injector;
+
+class PayloadConfiguration implements ConfigurationInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function apply(Injector $injector)
+    {
+        $injector->alias(
+            'Spark\PayloadInterface',
+            'Spark\Payload'
+        );
+    }
+}
+

--- a/src/Configuration/PayloadConfiguration.php
+++ b/src/Configuration/PayloadConfiguration.php
@@ -12,7 +12,7 @@ class PayloadConfiguration implements ConfigurationInterface
     public function apply(Injector $injector)
     {
         $injector->alias(
-            'Spark\PayloadInterface',
+            'Spark\Adr\PayloadInterface',
             'Spark\Payload'
         );
     }


### PR DESCRIPTION
This configures the injector to use Spark's `Payload` implementation of `PayloadInterface` so that Spark users don't have to in order to type hint against `PayloadInterface` in domain classes.