### PR TITLE
Add Settings and DotEnvConfiguration

### DIFF
--- a/src/Configuration/DotenvConfiguration.php
+++ b/src/Configuration/DotenvConfiguration.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Spark\Configuration;
+
+use Auryn\Injector;
+use josegonzalez\Dotenv\Loader;
+
+class DotenvConfiguation implements ConfigurationInterface
+{
+    public function apply(Injector $injector)
+    {
+        $injector->prepare(Loader::class, [$this, 'prepareLoader']);
+        $injector->delegate(Settings::class, [$this, 'getSettings']);
+    }
+
+    public function prepareLoader(Loader $loader, Injector $injector)
+    {
+        $loader->parse();
+        $injector->share($loader);
+    }
+
+    public function getSettings(Loader $loader)
+    {
+        return new Settings($loader->toArray());
+    }
+}

--- a/src/Configuration/DotenvConfiguration.php
+++ b/src/Configuration/DotenvConfiguration.php
@@ -21,6 +21,8 @@ class DotenvConfiguation implements ConfigurationInterface
 
     public function getSettings(Loader $loader)
     {
-        return new Settings($loader->toArray());
+        $settings = new Settings($loader->toArray());
+        $injector->share($settings);
+        return $settings;
     }
 }

--- a/src/Configuration/Settings.php
+++ b/src/Configuration/Settings.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spark\Configuration;
+
+class Settings extends \ArrayObject
+{
+}


### PR DESCRIPTION
Here's a POC for using this:

```php
<?php

namespace Spark\Configuration;

use Auryn\Injector;

class AuraSqlConfiguation implements ConfigurationInterface
{
    public function apply(Injector $injector)
    {
        $injector->delegate('Aura\Sql\PdoInterface', [$this, 'getPdo']);
        $injector->delegate('Aura\Sql\QueryFactory', [$this, 'getQueryFactory']);
    }
    
    public function getPdo(Settings $settings)
    {
        $dsn = $settings['dsn'];
        $username = isset($settings['username']) ? $settings['username'] : null;
        $password = isset($settings['password']) ? $settings['password'] : null;
        $options = isset($settings['options']) ? $settings['options'] : [];
        return new Aura\Sql\ExtendedPdo($dsn, $username, $password, $options);
    }
    
    public function getQueryFactory(Settings $settings)
    {
        $db = explode(':', $settings['dsn'])[0];
        return new Aura\Sql\QueryFactory($db);
    }
}
```