### PR TITLE
Alias request to server request

### DIFF
--- a/src/Configuration/DiactorosConfiguration.php
+++ b/src/Configuration/DiactorosConfiguration.php
@@ -24,5 +24,10 @@ class DiactorosConfiguration implements ConfigurationInterface
         );
 
         $injector->share('Psr\Http\Message\ServerRequestInterface');
+
+        $injector->alias(
+            'Psr\Http\Message\RequestInterface',
+            'Psr\Http\Message\ServerRequestInterface'
+        );
     }
 }

--- a/tests/Configuration/DiactorosConfigurationTest.php
+++ b/tests/Configuration/DiactorosConfigurationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace SparkTests\Configuration;
+
+use Auryn\Injector;
+use PHPUnit_Framework_TestCase as TestCase;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Spark\Configuration\DiactorosConfiguration;
+
+class DiactorosConfigurationTestCase extends TestCase
+{
+    public function testApply()
+    {
+        $injector = new Injector;
+
+        $config = new DiactorosConfiguration;
+        $config->apply($injector);
+
+        $server_request = $injector->make(ServerRequestInterface::class);
+
+        $this->assertInstanceOf('Zend\Diactoros\ServerRequest', $server_request);
+
+        $request = $injector->make(RequestInterface::class);
+
+        $this->assertSame($request, $server_request);
+
+        $response = $injector->make(ResponseInterface::class);
+
+        $this->assertInstanceOf('Zend\Diactoros\Response', $response);
+    }
+}


### PR DESCRIPTION
Allows type hinting against either `ServerRequestInterface` or
`RequestInterface` without creating separate instances for both.