### PR TITLE
Correct a docs issue regarding Plates integration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -415,12 +415,13 @@ class ResponderConfiguration implements ConfigurationInterface
 {
     public function apply(Injector $injector)
     {
-        $injector->prepare(FormatterResponder::class, [$this, 'prepareResponder']);
+        $injector->delegate(FormatterResponder::class, [$this, 'delegateResponder']);
     }
 
-    public function prepareResponder(FormatterResponder $responder)
+    public function delegateResponder(Injector $injector)
     {
-        $responder->withFormatters([
+        $responder = $injector->make(FormatterResponder::class);
+        return $responder->withFormatters([
             PlatesFormatter::class => 1.0
         ]);
     }


### PR DESCRIPTION
Forgot that `FormatterResponder` is immutable, so the example that tries to modify it to integrate Plates needs to use delegation, not preparation.