### PR TITLE
Add plates responder configuration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -99,10 +99,20 @@ To faciliate ease of reuse for groupings of configuration, Spark provides a [`Co
 
 For a Spark application to function properly, the `Injector` instance it uses must have a minimum level of configuration. This configuration is applied using the [`DefaultConfigurationSet`](https://github.com/sparkphp/spark/blob/master/src/Configuration/DefaultConfigurationSet.php) class, which extends [`ConfigurationSet`](https://github.com/sparkphp/spark/blob/master/src/Configuration/ConfigurationSet.php) to provide a grouping of configurations for several libraries.
 
+### Default Configuration
+
+The following configurations are used by `DefaultConfigurationSet`:
+
 * [`AurynConfiguration`](https://github.com/sparkphp/spark/blob/master/src/Configuration/AurynConfiguration.php) - Use the `Injector` instance as a singleton and to resolve [actions](https://github.com/pmjones/adr#controller-vs-action)
 * [`DiactorosConfiguration`](https://github.com/sparkphp/spark/blob/master/src/Configuration/DiactorosConfiguration.php) - Use [Diactoros](https://github.com/zendframework/zend-diactoros/) for the framework [PSR-7](http://www.php-fig.org/psr/psr-7/) implementation
 * [`NegotiationConfiguration`](https://github.com/sparkphp/spark/blob/master/src/Configuration/NegotiationConfiguration.php) - Use [Negotiation](https://github.com/willdurand/negotiation) for [content negotiation](https://en.wikipedia.org/wiki/Content_negotiation)
 * [`RelayConfiguration`](https://github.com/sparkphp/spark/blob/master/src/Configuration/RelayConfiguration.php) - Use [Relay](http://relayphp.com) for the framework middleware dispatcher
+
+### Optional Configurations
+
+The following configurations are available but not used by default:
+
+* [`PlatesResponderConfiguration`](https://github.com/sparkphp/spark/blob/master/src/Configuration/PlatesResponderConfiguration.php) - Use [Plates](http://platesphp.com/) as the default [responder](#responders)
 
 ## Bootstrap
 
@@ -403,31 +413,28 @@ The default configuration looks like this:
 
 ### Using Plates
 
-Using [`PlatesFormatter`](https://github.com/sparkphp/spark/blob/master/src/Formatter/PlatesFormatter.php) requires changing the formatters used by [`FormattedResponder`](https://github.com/sparkphp/spark/blob/master/src/Responder/FormattedResponder.php). This can be accomplished using a [custom configuration](#configuration) as in the example below.
+Using [`PlatesFormatter`](https://github.com/sparkphp/spark/blob/master/src/Formatter/PlatesFormatter.php) requires changing the formatters used by [`FormattedResponder`](https://github.com/sparkphp/spark/blob/master/src/Responder/FormattedResponder.php). The easiest way to do this is by using the `PlatesResponderConfiguration` as in the example below:
 
 ```php
-use Auryn\Injector;
-use Spark\Configuration\ConfigurationInterface;
-use Spark\Formatter\PlatesFormatter;
-use Spark\Responder\FormatterResponder;
+use Spark\Configuration\PlatesResponderConfiguration;
 
-class ResponderConfiguration implements ConfigurationInterface
-{
-    public function apply(Injector $injector)
-    {
-        $injector->prepare(FormatterResponder::class, [$this, 'prepareResponder']);
-    }
-
-    public function prepareResponder(FormattedResponder $responder)
-    {
-        return $responder->withFormatters([
-            PlatesFormatter::class => 1.0
-        ]);
-    }
-}
+$configuration = new PlatesResponderConfiguration;
+$configuration->apply($injector);
 ```
 
-Note that this example completely replaces the default group of formatters of [`FormattedResponder`](https://github.com/sparkphp/spark/blob/master/src/Responder/FormattedResponder.php). If you instead want to add to that group of formatters, you can invoke the responder's `getFormatters()` method to get an array of the same form as the one shown above, modify it, and then invoke its `withFormatters()` method with the modified array.
+If you are using the [`DefaultConfigurationSet`](https://github.com/sparkphp/spark/blob/master/src/Configuration/DefaultConfigurationSet.php) you can add this configuration to the default set:
+
+```php
+use Spark\Configuration\DefaultConfigurationSet;
+use Spark\Configuration\PlatesResponderConfiguration;
+
+$configuration = new DefaultConfigurationSet([
+    PlatesResponderConfiguration::class
+]);
+$configuration->apply($injector);
+```
+
+Note that this will completely replace the default group of formatters of [`FormattedResponder`](https://github.com/sparkphp/spark/blob/master/src/Responder/FormattedResponder.php). If you instead want to add to that group of formatters, you will need to use a custom configuration that modifies the response of `getFormatters()` and then invoke `withFormatters()` method to store the modified array.
 
 ### Changing Responders
 

--- a/src/Configuration/DefaultConfigurationSet.php
+++ b/src/Configuration/DefaultConfigurationSet.php
@@ -4,14 +4,16 @@ namespace Spark\Configuration;
 
 class DefaultConfigurationSet extends ConfigurationSet
 {
-    public function __construct()
+    public function __construct(array $classes = [])
     {
-        parent::__construct([
+        $defaults = [
             AurynConfiguration::class,
             DiactorosConfiguration::class,
             NegotiationConfiguration::class,
             PayloadConfiguration::class,
             RelayConfiguration::class,
-        ]);
+        ];
+
+        parent::__construct(array_merge($defaults, $classes));
     }
 }

--- a/src/Configuration/PlatesResponderConfiguration.php
+++ b/src/Configuration/PlatesResponderConfiguration.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spark\Configuration;
+
+use Auryn\Injector;
+use Spark\Formatter\PlatesFormatter;
+use Spark\Responder\FormattedResponder;
+
+class PlatesResponderConfiguration implements ConfigurationInterface
+{
+    public function apply(Injector $injector)
+    {
+        $injector->prepare(FormattedResponder::class, function (FormattedResponder $responder) {
+            return $responder->withFormatters([
+                PlatesFormatter::class => 1.0,
+            ]);
+        });
+    }
+}

--- a/tests/Configuration/ConfigurationTestCase.php
+++ b/tests/Configuration/ConfigurationTestCase.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SparkTests\Configuration;
+
+use Auryn\Injector;
+use PHPUnit_Framework_TestCase as TestCase;
+
+abstract class ConfigurationTestCase extends TestCase
+{
+    /**
+     * @var Injector
+     */
+    protected $injector;
+
+    /**
+     * @return array
+     */
+    abstract protected function getConfigurations();
+
+    public function setUp()
+    {
+        $this->injector = new Injector;
+
+        foreach ($this->getConfigurations() as $config) {
+            $config->apply($this->injector);
+        }
+    }
+}

--- a/tests/Configuration/DiactorosConfigurationTest.php
+++ b/tests/Configuration/DiactorosConfigurationTest.php
@@ -2,31 +2,31 @@
 
 namespace SparkTests\Configuration;
 
-use Auryn\Injector;
-use PHPUnit_Framework_TestCase as TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Spark\Configuration\DiactorosConfiguration;
 
-class DiactorosConfigurationTestCase extends TestCase
+class DiactorosConfigurationTest extends ConfigurationTestCase
 {
+    protected function getConfigurations()
+    {
+        return [
+            new DiactorosConfiguration,
+        ];
+    }
+
     public function testApply()
     {
-        $injector = new Injector;
-
-        $config = new DiactorosConfiguration;
-        $config->apply($injector);
-
-        $server_request = $injector->make(ServerRequestInterface::class);
+        $server_request = $this->injector->make(ServerRequestInterface::class);
 
         $this->assertInstanceOf('Zend\Diactoros\ServerRequest', $server_request);
 
-        $request = $injector->make(RequestInterface::class);
+        $request = $this->injector->make(RequestInterface::class);
 
         $this->assertSame($request, $server_request);
 
-        $response = $injector->make(ResponseInterface::class);
+        $response = $this->injector->make(ResponseInterface::class);
 
         $this->assertInstanceOf('Zend\Diactoros\Response', $response);
     }

--- a/tests/Configuration/PlatesResponderConfigurationTest.php
+++ b/tests/Configuration/PlatesResponderConfigurationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SparkTests\Configuration;
+
+use Spark\Configuration\AurynConfiguration;
+use Spark\Configuration\NegotiationConfiguration;
+use Spark\Configuration\PlatesResponderConfiguration;
+use Spark\Formatter\PlatesFormatter;
+use Spark\Responder\FormattedResponder;
+
+class PlatesResponderConfigurationTest extends ConfigurationTestCase
+{
+    protected function getConfigurations()
+    {
+        return [
+            new AurynConfiguration,
+            new NegotiationConfiguration,
+            new PlatesResponderConfiguration,
+        ];
+    }
+
+    public function testApply()
+    {
+        $responder = $this->injector->make(FormattedResponder::class);
+        $formatters = $responder->getFormatters();
+
+        $this->assertArrayHasKey(PlatesFormatter::class, $formatters);
+        $this->assertSame(1.0, $formatters[PlatesFormatter::class]);
+    }
+}

--- a/tests/Configuration/RelayConfigurationTest.php
+++ b/tests/Configuration/RelayConfigurationTest.php
@@ -1,30 +1,28 @@
 <?php
 namespace SparkTests\Configuration;
 
-use Auryn\Injector;
-use PHPUnit_Framework_TestCase as TestCase;
 use Relay\MiddlewareInterface;
 use Relay\Relay;
 use Spark\Configuration\AurynConfiguration;
 use Spark\Configuration\RelayConfiguration;
 use Spark\Middleware\Collection as MiddlewareCollection;
 
-class RelayConfigurationTestCase extends TestCase
+class RelayConfigurationTest extends ConfigurationTestCase
 {
+    protected function getConfigurations()
+    {
+        return [
+            new AurynConfiguration,
+            new RelayConfiguration,
+        ];
+    }
+
     public function testApply()
     {
-        $injector = new Injector;
-
-        $auryn = new AurynConfiguration;
-        $auryn->apply($injector);
-
-        $relay = new RelayConfiguration;
-        $relay->apply($injector);
-
         $middleware = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
-        $injector->define(MiddlewareCollection::class, [':middlewares' => [$middleware]]);
+        $this->injector->define(MiddlewareCollection::class, [':middlewares' => [$middleware]]);
 
-        $dispatcher = $injector->make(Relay::class);
+        $dispatcher = $this->injector->make(Relay::class);
 
         $this->assertInstanceOf(Relay::class, $dispatcher);
     }


### PR DESCRIPTION
Allows Plates to be used easily without having to implement a custom
configuration.

Also allows easier extension of the `DefaultConfigurationSet` by
including the `$classes` parameter, which is merged with the defaults.

Simplifies the configuration tests by defining a base test case that
automatically creates the injector and applies all required configs.