### PR TITLE
Stop using response formatter with empty output

### DIFF
--- a/src/Responder/FormattedResponder.php
+++ b/src/Responder/FormattedResponder.php
@@ -71,10 +71,24 @@ class FormattedResponder implements ResponderInterface
         ResponseInterface      $response,
         PayloadInterface       $payload
     ) {
-        $formatter = $this->formatter($request);
-        $response  = $this->format($response, $formatter, $payload);
+        if ($this->hasOutput($payload)) {
+            $formatter = $this->formatter($request);
+            $response  = $this->format($response, $formatter, $payload);
+        }
 
         return $response;
+    }
+
+    /**
+     * Determine if the payload has usable output
+     *
+     * @param PayloadInterface $payload
+     *
+     * @return boolean
+     */
+    protected function hasOutput(PayloadInterface $payload)
+    {
+        return (bool) $payload->getOutput();
     }
 
     /**

--- a/tests/Responder/FormattedResponderTest.php
+++ b/tests/Responder/FormattedResponderTest.php
@@ -68,4 +68,13 @@ class FormattedResponderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['application/json'], $response->getHeader('Content-Type'));
         $this->assertEquals('{"test":"test"}', (string) $response->getBody());
     }
+
+    public function testEmptyPayload()
+    {
+        $payload = new Payload;
+        $request = $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->getMock();
+        $response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
+        $returned = call_user_func($this->responder, $request, $response, $payload);
+        $this->assertSame($returned, $response);
+    }
 }


### PR DESCRIPTION
By eliminating attempts to run formatting on blank output, it becomes
easier to use redirection in combination with other responses.