### PR TITLE
Allow middleware to be added to collections

### DIFF
--- a/src/Middleware/Collection.php
+++ b/src/Middleware/Collection.php
@@ -9,11 +9,40 @@ class Collection extends \ArrayObject
     /**
      * @param array $middlewares
      */
-    public function __construct(array $middlewares)
+    public function __construct(array $middlewares = [])
     {
         $this->validate($middlewares);
-
         parent::__construct($middlewares);
+    }
+
+    /**
+     * Add middleware to the collection
+     *
+     * By default will append the middleware to the end of the stack. Optionally
+     * can insert the middleware in the stack before an existing one.
+     *
+     * @param string $class
+     * @param mixed $before
+     *
+     * @return static
+     */
+    public function withAddedMiddleware($class, $before = null)
+    {
+        $this->validate([$class]);
+
+        $middleware = $this->getArrayCopy();
+
+        $offset = array_search($before, $middleware);
+        if ($offset === false) {
+            $offset = count($middleware);
+        }
+
+        array_splice($middleware, $offset, 0, $class);
+
+        $copy = clone $this;
+        $copy->exchangeArray($middleware);
+
+        return $copy;
     }
 
     /**

--- a/tests/Middleware/CollectionTest.php
+++ b/tests/Middleware/CollectionTest.php
@@ -8,26 +8,50 @@ use Spark\Middleware\Collection as MiddlewareCollection;
 class MiddlewareCollectionTest extends TestCase
 {
     /**
-     * @param mixed $middlewares
-     * @param string $message
+     * @expectedException \DomainException
+     * @expectedExceptionRegExp /must be callable or implement __invoke/i
      */
     public function testWithInvalidEntries()
     {
-        $this->setExpectedException(
-            '\\DomainException',
-            'All elements of $middlewares must be callable or implement __invoke()'
-        );
-
-        $middlewares = ['foo'];
-        $collection = new MiddlewareCollection($middlewares);
+        $middleware = ['foo'];
+        $collection = new MiddlewareCollection($middleware);
     }
 
     public function testWithValidEntries()
     {
-        $middleware = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
-        $callback = function() { };
-        $middlewares = [$callback, $middleware];
-        $collection = new MiddlewareCollection($middlewares);
-        $this->assertSame($middlewares, $collection->getArrayCopy());
+        $middleware = [
+            $this->getMock(MiddlewareInterface::class),
+            function () {
+            }
+        ];
+        $collection = new MiddlewareCollection($middleware);
+        $this->assertSame($middleware, $collection->getArrayCopy());
+    }
+
+    public function testAdd()
+    {
+        $collection = new MiddlewareCollection;
+        $this->assertEmpty($collection->getArrayCopy());
+
+        $m1 = $this->getMiddlewareClass();
+        $m2 = $this->getMiddlewareClass();
+        $m3 = $this->getMiddlewareClass();
+
+        $collection = $collection->withAddedMiddleware($m1);
+        $this->assertContains($m1, $collection);
+
+        // Insert the second middleware before the first and append the third.
+        $collection = $collection->withAddedMiddleware($m2, $m1);
+        $collection = $collection->withAddedMiddleware($m3);
+
+        $this->assertSame([$m2, $m1, $m3], $collection->getArrayCopy());
+    }
+
+    /**
+     * @return string
+     */
+    private function getMiddlewareClass()
+    {
+        return get_class($this->getMock(MiddlewareInterface::class));
     }
 }


### PR DESCRIPTION
Often it is necessary to add middleware to an existing set and
sometimes it needs to be placed specifically. Creating a whole new
collection is often tedious and can be easily abstracted.

Fixes #79