### PR TITLE
Merge input class from adr package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "rdlowrey/auryn": "^1.1",
         "relay/relay": "^1",
         "relay/middleware": "~0.1",
-        "sparkphp/adr": "^0.2.3",
+        "sparkphp/adr": "^0.3",
         "willdurand/negotiation": "~1.4",
         "zendframework/zend-diactoros": "~1.0"
     },

--- a/src/Input.php
+++ b/src/Input.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Spark;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Spark\Adr\InputInterface;
+
+class Input implements InputInterface
+{
+    /**
+     * Flatten all input from the request
+     *
+     * @param ServerRequestInterface $request
+     *
+     * @return array
+     */
+    public function __invoke(
+        ServerRequestInterface $request
+    ) {
+        $input = [];
+
+        if ($params = $request->getQueryParams()) {
+            $input = array_replace($input, $params);
+        }
+        if ($params = $request->getParsedBody()) {
+            $input = array_replace($input, $params);
+        }
+        if ($params = $request->getUploadedFiles()) {
+            $input = array_replace($input, $params);
+        }
+        if ($params = $request->getCookieParams()) {
+            $input = array_replace($input, $params);
+        }
+        if ($params = $request->getAttributes()) {
+            $input = array_replace($input, $params);
+        }
+
+        return $input;
+    }
+}

--- a/src/Router.php
+++ b/src/Router.php
@@ -22,7 +22,7 @@ class Router
     /**
      * @var string
      */
-    private $input = 'Spark\Adr\Input';
+    private $input = 'Spark\Input';
 
     /**
      * @var string

--- a/tests/Fake/FakeInput.php
+++ b/tests/Fake/FakeInput.php
@@ -1,7 +1,7 @@
 <?php
 namespace SparkTests\Fake;
 
-use Spark\Adr\Input;
+use Spark\Input;
 
 class FakeInput extends Input
 {

--- a/tests/Handler/ActionHandlerTest.php
+++ b/tests/Handler/ActionHandlerTest.php
@@ -22,7 +22,7 @@ class ActionHandlerTest extends TestCase
         $request = ServerRequestFactory::fromGlobals();
         $response = new Response();
 
-        $action = new Action('Spark\Adr\Input', 'SparkTests\Fake\FakeDomain', 'Spark\Responder\ChainedResponder');
+        $action = new Action('Spark\Input', 'SparkTests\Fake\FakeDomain', 'Spark\Responder\ChainedResponder');
         $request = $request->withAttribute('spark/adr:action', $action)
                         ->withAttribute('test', 'success');
 

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace SparkTests;
+
+use Psr\Http\Message\UploadedFileInterface;
+use Spark\Input;
+use Zend\Diactoros\ServerRequest;
+
+class InputTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCollectEmptyRequest()
+    {
+        $found = $this->execute(new ServerRequest);
+        $this->assertEmpty($found);
+    }
+
+    public function testQueryParams()
+    {
+        $query = [
+            'query' => 'string',
+        ];
+
+        $request = new ServerRequest;
+        $request = $request->withQueryParams($query);
+
+        $found = $this->execute($request);
+        $this->assertSame($query, $found);
+    }
+
+    public function testParsedBody()
+    {
+        $body = [
+            'body' => 'parsed',
+        ];
+
+        $request = new ServerRequest;
+        $request = $request->withParsedBody($body);
+
+        $found = $this->execute($request);
+        $this->assertSame($body, $found);
+    }
+
+    public function testUploadedFiles()
+    {
+        $files = [
+            'file' => $this->getMock(UploadedFileInterface::class),
+        ];
+
+        $request = new ServerRequest;
+        $request = $request->withUploadedFiles($files);
+
+        $found = $this->execute($request);
+        $this->assertSame($files, $found);
+    }
+
+    public function testCookieParams()
+    {
+        $cookies = [
+            'cookie' => 'nomnomnom',
+        ];
+
+        $request = new ServerRequest;
+        $request = $request->withCookieParams($cookies);
+
+        $found = $this->execute($request);
+        $this->assertSame($cookies, $found);
+    }
+
+    public function testAttributes()
+    {
+        $attrs = [
+            'attr' => 'stored',
+        ];
+
+        $request = new ServerRequest;
+        foreach ($attrs as $name => $value) {
+            $request = $request->withAttribute($name, $value);
+        }
+
+        $found = $this->execute($request);
+        $this->assertSame($attrs, $found);
+    }
+
+    public function testMerge()
+    {
+        $request = new ServerRequest;
+
+        $value = [
+            'merge' => 'query',
+        ];
+        $request = $request->withQueryParams($value);
+        $this->assertSame($value, $this->execute($request));
+
+        $value = [
+            'merge' => 'body',
+        ];
+        $request = $request->withParsedBody($value);
+        $this->assertSame($value, $this->execute($request));
+
+        $value = [
+            'merge' => $this->getMock(UploadedFileInterface::class),
+        ];
+        $request = $request->withParsedBody($value);
+        $this->assertSame($value, $this->execute($request));
+
+        $value = [
+            'merge' => 'cookie',
+        ];
+        $request = $request->withCookieParams($value);
+        $this->assertSame($value, $this->execute($request));
+
+        $value = [
+            'merge' => 'attr',
+        ];
+        $request = $request->withAttribute(key($value), current($value));
+        $this->assertSame($value, $this->execute($request));
+    }
+
+    /**
+     * Collect input from the request
+     *
+     * @param ServerRequest $request
+     *
+     * @return array
+     */
+    private function execute(ServerRequest $request)
+    {
+        return call_user_func(new Input, $request);
+    }
+}

--- a/tests/Router/RouteTest.php
+++ b/tests/Router/RouteTest.php
@@ -6,10 +6,9 @@ use Spark\Router\Route;
 
 class RouteTest extends TestCase
 {
-
     public function testGetSet()
     {
-        $route = new Route('', 'Spark\Adr\Input', 'Spark\Responder\Responder');
+        $route = new Route('', 'Spark\Input', 'Spark\Responder\Responder');
 
         $domain = 'SparkTests\Fake\FakeDomain';
         $route->setDomain($domain);
@@ -22,7 +21,5 @@ class RouteTest extends TestCase
         $responder = 'SparkTests\Fake\FakeResponder';
         $route->setResponder($responder);
         $this->assertEquals($responder, $route->getResponder());
-
     }
-
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -2,7 +2,7 @@
 namespace SparkTests;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use Spark\Adr\Input;
+use Spark\Input;
 use Spark\Router;
 use SparkTests\Fake\FakeInput;
 use Zend\Diactoros\ServerRequest;
@@ -30,9 +30,8 @@ class RouterTest extends TestCase
         $route = current($this->router->getRoutes());
         $this->assertInstanceOf('\Spark\Router\Route', $route);
         $this->assertEquals('Spark\Responder\ChainedResponder', $route->getResponder());
-        $this->assertEquals('Spark\Adr\Input', $route->getInput());
+        $this->assertEquals('Spark\Input', $route->getInput());
         $this->assertEquals('SparkTests\Fake\FakeDomain', $route->getDomain());
-
     }
 
     public function testRouteInput()
@@ -59,7 +58,6 @@ class RouterTest extends TestCase
 
         $this->assertEquals($input, $route->getInput());
         $this->assertEquals($responder, $route->getResponder());
-
     }
 
     public function routeMethodProvider()
@@ -84,5 +82,4 @@ class RouterTest extends TestCase
 
         $this->assertInstanceOf('Spark\Router\Route', $route);
     }
-
 }


### PR DESCRIPTION
Since this is the only package that makes use of the Input class,
it should be the one to hold it. The ADR package should only contain
interfaces and not concrete classes.

Also adds unit tests for the input class.

Refs sparkphp/adr#7