### PR TITLE
Use Destrukt for config and middleware sets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,12 @@
         "arbiter/arbiter": "~0.1",
         "nikic/fast-route": "~0.6",
         "rdlowrey/auryn": "^1.1",
-        "relay/relay": "^1",
+        "relay/relay": "^1.1",
         "relay/middleware": "~0.1",
         "sparkphp/adr": "^0.4",
         "willdurand/negotiation": "~1.4",
-        "zendframework/zend-diactoros": "^1.0.4"
+        "zendframework/zend-diactoros": "^1.0.4",
+        "shadowhand/destrukt": "^0.5.2"
     },
     "require-dev": {
         "league/plates": "~3.1",

--- a/src/Configuration/ConfigurationSet.php
+++ b/src/Configuration/ConfigurationSet.php
@@ -3,39 +3,25 @@
 namespace Spark\Configuration;
 
 use Auryn\Injector;
+use Shadowhand\Destrukt\Set;
 use Spark\Exception\ConfigurationException;
 
-class ConfigurationSet implements ConfigurationInterface
+class ConfigurationSet extends Set implements ConfigurationInterface
 {
     /**
-     * @var array
+     * @inheritDoc
+     *
+     * @throws ConfigurationException If any class is not of the expected type
      */
-    protected $classes = [];
-
-    /**
-     * @param array $classes
-     */
-    public function __construct(array $classes = [])
+    public function validate(array $classes)
     {
+        parent::validate($classes);
+
         foreach ($classes as $class) {
-            $this->add($class);
+            if (!is_subclass_of($class, ConfigurationInterface::class)) {
+                throw ConfigurationException::invalidClass($class);
+            }
         }
-    }
-
-    /**
-     * Add a new configuration class to the set
-     *
-     * @param string $class
-     *
-     * @return self
-     */
-    public function add($class)
-    {
-        $this->validate($class);
-
-        $this->classes[] = $class;
-
-        return $this;
     }
 
     /**
@@ -43,25 +29,9 @@ class ConfigurationSet implements ConfigurationInterface
      */
     public function apply(Injector $injector)
     {
-        foreach ($this->classes as $class) {
+        foreach ($this as $class) {
             $configuration = $injector->make($class);
             $configuration->apply($injector);
-        }
-    }
-
-    /**
-     * Checks that the given class is valid for configuration
-     *
-     * @param string $class
-     *
-     * @return void
-     *
-     * @throws ConfigurationException If the class is not of the expected type
-     */
-    protected function validate($class)
-    {
-        if (!is_subclass_of($class, ConfigurationInterface::class)) {
-            throw ConfigurationException::invalidClass($class);
         }
     }
 }

--- a/src/Middleware/Collection.php
+++ b/src/Middleware/Collection.php
@@ -3,58 +3,22 @@
 namespace Spark\Middleware;
 
 use Relay\MiddlewareInterface;
+use Shadowhand\Destrukt\Set;
 
-class Collection extends \ArrayObject
+class Collection extends Set
 {
-    /**
-     * @param array $middlewares
-     */
-    public function __construct(array $middlewares = [])
-    {
-        $this->validate($middlewares);
-        parent::__construct($middlewares);
-    }
-
-    /**
-     * Add middleware to the collection
-     *
-     * By default will append the middleware to the end of the stack. Optionally
-     * can insert the middleware in the stack before an existing one.
-     *
-     * @param string $class
-     * @param mixed $before
-     *
-     * @return static
-     */
-    public function withAddedMiddleware($class, $before = null)
-    {
-        $this->validate([$class]);
-
-        $middleware = $this->getArrayCopy();
-
-        $offset = array_search($before, $middleware);
-        if ($offset === false) {
-            $offset = count($middleware);
-        }
-
-        array_splice($middleware, $offset, 0, $class);
-
-        $copy = clone $this;
-        $copy->exchangeArray($middleware);
-
-        return $copy;
-    }
-
     /**
      * @param array $middlewares
      * @throws \DomainException if $middlewares does not conform to type expectations
      */
-    protected function validate(array $middlewares)
+    public function validate(array $middlewares)
     {
+        parent::validate($middlewares);
+
         foreach ($middlewares as $middleware) {
             if (!(is_callable($middleware) || method_exists($middleware, '__invoke'))) {
                 throw new \DomainException(
-                    'All elements of $middlewares must be callable or implement __invoke()'
+                    'All elements of $middlewares must be callable'
                 );
             }
         }

--- a/src/Middleware/DefaultCollection.php
+++ b/src/Middleware/DefaultCollection.php
@@ -11,15 +11,15 @@ use Spark\Handler\RouteHandler;
 
 class DefaultCollection extends Collection
 {
-    public function __construct()
+    public function __construct(array $middleware = [])
     {
-        parent::__construct([
+        parent::__construct(array_merge([
             ResponseSender::class,
             ExceptionHandler::class,
             RouteHandler::class,
             JsonContentHandler::class,
             FormContentHandler::class,
             ActionHandler::class,
-        ]);
+        ], $middleware));
     }
 }

--- a/tests/Configuration/ConfigurationSetTest.php
+++ b/tests/Configuration/ConfigurationSetTest.php
@@ -39,7 +39,6 @@ class ConfigurationSetTest extends TestCase
     public function testInvalidClass()
     {
         $set = new ConfigurationSet;
-
-        $set->add('\stdClass');
+        $set = $set->withValue('\stdClass');
     }
 }

--- a/tests/Configuration/DefaultConfigurationSetTest.php
+++ b/tests/Configuration/DefaultConfigurationSetTest.php
@@ -2,7 +2,6 @@
 
 namespace SparkTests\Configuration;
 
-use Auryn\Injector;
 use PHPUnit_Framework_TestCase as TestCase;
 use Spark\Configuration\DefaultConfigurationSet;
 
@@ -10,8 +9,6 @@ class DefaultConfigurationTest extends TestCase
 {
     public function testDefault()
     {
-        $injector = $this->prophesize(Injector::class);
-
         $expected = [
             'Spark\Configuration\AurynConfiguration',
             'Spark\Configuration\DiactorosConfiguration',
@@ -20,17 +17,7 @@ class DefaultConfigurationTest extends TestCase
             'Spark\Configuration\RelayConfiguration',
         ];
 
-        foreach ($expected as $class) {
-            // We have to mock the interaction of the configuration,
-            // because the values of the configuration are not public.
-            // This is probably something we should refactor in the future...
-            // maybe use Shadowhand\Destrukt\Set as the base?
-            $mock = $this->prophesize($class);
-            $injector->make($class)->willReturn($mock->reveal());
-            $mock->apply($injector->reveal())->shouldBeCalled();
-        }
-
         $set = new DefaultConfigurationSet;
-        $set->apply($injector->reveal());
+        $this->assertSame($expected, $set->toArray());
     }
 }

--- a/tests/Configuration/RelayConfigurationTest.php
+++ b/tests/Configuration/RelayConfigurationTest.php
@@ -19,9 +19,6 @@ class RelayConfigurationTest extends ConfigurationTestCase
 
     public function testApply()
     {
-        $middleware = $this->getMockBuilder(MiddlewareInterface::class)->getMock();
-        $this->injector->define(MiddlewareCollection::class, [':middlewares' => [$middleware]]);
-
         $dispatcher = $this->injector->make(Relay::class);
 
         $this->assertInstanceOf(Relay::class, $dispatcher);

--- a/tests/Middleware/CollectionTest.php
+++ b/tests/Middleware/CollectionTest.php
@@ -9,7 +9,7 @@ class CollectionTest extends TestCase
 {
     /**
      * @expectedException \DomainException
-     * @expectedExceptionRegExp /must be callable or implement __invoke/i
+     * @expectedExceptionRegExp /must be callable/i
      */
     public function testWithInvalidEntries()
     {
@@ -25,26 +25,26 @@ class CollectionTest extends TestCase
             }
         ];
         $collection = new MiddlewareCollection($middleware);
-        $this->assertSame($middleware, $collection->getArrayCopy());
+        $this->assertSame($middleware, $collection->toArray());
     }
 
     public function testAdd()
     {
         $collection = new MiddlewareCollection;
-        $this->assertEmpty($collection->getArrayCopy());
+        $this->assertEmpty($collection->toArray());
 
         $m1 = $this->getMiddlewareClass();
         $m2 = $this->getMiddlewareClass();
         $m3 = $this->getMiddlewareClass();
 
-        $collection = $collection->withAddedMiddleware($m1);
+        $collection = $collection->withValue($m1);
         $this->assertContains($m1, $collection);
 
         // Insert the second middleware before the first and append the third.
-        $collection = $collection->withAddedMiddleware($m2, $m1);
-        $collection = $collection->withAddedMiddleware($m3);
+        $collection = $collection->withValueBefore($m2, $m1);
+        $collection = $collection->withValueAfter($m3, $m1);
 
-        $this->assertSame([$m2, $m1, $m3], $collection->getArrayCopy());
+        $this->assertSame([$m2, $m1, $m3], $collection->toArray());
     }
 
     /**
@@ -52,6 +52,6 @@ class CollectionTest extends TestCase
      */
     private function getMiddlewareClass()
     {
-        return get_class($this->getMock(MiddlewareInterface::class));
+        return get_class($this->prophesize(MiddlewareInterface::class)->reveal());
     }
 }


### PR DESCRIPTION
Enables a standard, immutable interface to be used for both config and
middleware sets. Also ensures that config and middleware is never
duplicated.