### PR TITLE
Correct aliases for diactoros

### DIFF
--- a/src/Configuration/DiactorosConfiguration.php
+++ b/src/Configuration/DiactorosConfiguration.php
@@ -12,22 +12,23 @@ class DiactorosConfiguration implements ConfigurationInterface
     public function apply(Injector $injector)
     {
         $injector->alias(
+            'Psr\Http\Message\RequestInterface',
+            'Zend\Diactoros\Request'
+        );
+
+        $injector->alias(
             'Psr\Http\Message\ResponseInterface',
             'Zend\Diactoros\Response'
         );
 
-        $injector->share('Psr\Http\Message\ResponseInterface');
-
-        $injector->delegate(
+        $injector->alias(
             'Psr\Http\Message\ServerRequestInterface',
-            'Zend\Diactoros\ServerRequestFactory::fromGlobals'
+            'Zend\Diactoros\ServerRequest'
         );
 
-        $injector->share('Psr\Http\Message\ServerRequestInterface');
-
-        $injector->alias(
-            'Psr\Http\Message\RequestInterface',
-            'Psr\Http\Message\ServerRequestInterface'
+        $injector->delegate(
+            'Zend\Diactoros\ServerRequest',
+            'Zend\Diactoros\ServerRequestFactory::fromGlobals'
         );
     }
 }

--- a/tests/Configuration/DiactorosConfigurationTest.php
+++ b/tests/Configuration/DiactorosConfigurationTest.php
@@ -16,18 +16,21 @@ class DiactorosConfigurationTest extends ConfigurationTestCase
         ];
     }
 
-    public function testApply()
+    public function dataMapping()
     {
-        $server_request = $this->injector->make(ServerRequestInterface::class);
+        return [
+            [RequestInterface::class, 'Zend\Diactoros\Request'],
+            [ResponseInterface::class, 'Zend\Diactoros\Response'],
+            [ServerRequestInterface::class, 'Zend\Diactoros\ServerRequest'],
+        ];
+    }
 
-        $this->assertInstanceOf('Zend\Diactoros\ServerRequest', $server_request);
-
-        $request = $this->injector->make(RequestInterface::class);
-
-        $this->assertSame($request, $server_request);
-
-        $response = $this->injector->make(ResponseInterface::class);
-
-        $this->assertInstanceOf('Zend\Diactoros\Response', $response);
+    /**
+     * @dataProvider dataMapping
+     */
+    public function testInstances($interface, $class)
+    {
+        $instance = $this->injector->make($interface);
+        $this->assertInstanceOf($class, $instance);
     }
 }


### PR DESCRIPTION
Sharing requests and responses does not work, because the objects are
immutable and the shared instance would almost never be the instance
that would be used by a method.

Also adds missing alias for `RequestInterface`.