### PR TITLE
Add configuration for middleware

### DIFF
--- a/src/Configuration/DefaultConfigurationSet.php
+++ b/src/Configuration/DefaultConfigurationSet.php
@@ -10,6 +10,7 @@ class DefaultConfigurationSet extends ConfigurationSet
             AurynConfiguration::class,
             DiactorosConfiguration::class,
             NegotiationConfiguration::class,
+            MiddlewareConfiguration::class,
             PayloadConfiguration::class,
             RelayConfiguration::class,
         ];

--- a/src/Configuration/MiddlewareConfiguration.php
+++ b/src/Configuration/MiddlewareConfiguration.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spark\Configuration;
+
+use Auryn\Injector;
+
+class MiddlewareConfiguration implements ConfigurationInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function apply(Injector $injector)
+    {
+        $injector->alias(
+            'Spark\Middleware\Collection',
+            'Spark\Middleware\DefaultCollection'
+        );
+    }
+}

--- a/tests/Configuration/DefaultConfigurationSetTest.php
+++ b/tests/Configuration/DefaultConfigurationSetTest.php
@@ -13,6 +13,7 @@ class DefaultConfigurationTest extends TestCase
             'Spark\Configuration\AurynConfiguration',
             'Spark\Configuration\DiactorosConfiguration',
             'Spark\Configuration\NegotiationConfiguration',
+            'Spark\Configuration\MiddlewareConfiguration',
             'Spark\Configuration\PayloadConfiguration',
             'Spark\Configuration\RelayConfiguration',
         ];


### PR DESCRIPTION
The alias from `Collection` to `DefaultCollection` can be done always.
If the user wants to modify the default collection, they can use a
`prepare` to add/remove middleware.

One less thing in `index.php`!