### PR TITLE
Add a redirect responder

### DIFF
--- a/src/Responder/ChainedResponder.php
+++ b/src/Responder/ChainedResponder.php
@@ -20,6 +20,7 @@ class ChainedResponder implements ResponderInterface
      */
     private $responders = [
         'Spark\Responder\FormattedResponder',
+        'Spark\Responder\RedirectResponder',
     ];
 
     /**

--- a/src/Responder/RedirectResponder.php
+++ b/src/Responder/RedirectResponder.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Spark\Responder;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Spark\Adr\PayloadInterface;
+use Spark\Adr\ResponderInterface;
+
+class RedirectResponder implements ResponderInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        PayloadInterface $payload
+    ) {
+        if ($this->hasRedirect($payload)) {
+            $messages = $payload->getMessages() + [
+                'status' => 302,
+            ];
+
+            return $response
+                ->withStatus($messages['status'])
+                ->withHeader('Location', $messages['redirect']);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Check if the payload contains a redirect
+     *
+     * @param PayloadInterface $payload
+     *
+     * @return boolean
+     */
+    private function hasRedirect(PayloadInterface $payload)
+    {
+        $messages = $payload->getMessages();
+        return !empty($messages['redirect']);
+    }
+}

--- a/tests/Responder/RedirectResponderTest.php
+++ b/tests/Responder/RedirectResponderTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SparkTests\Responder;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Spark\Payload;
+use Spark\Responder\RedirectResponder;
+use Zend\Diactoros\Response;
+
+class RedirectResponderTest extends TestCase
+{
+    /**
+     * @var RedirectResponder
+     */
+    private $responder;
+
+    public function setUp()
+    {
+        $this->responder = new RedirectResponder;
+    }
+
+    public function testRedirect()
+    {
+        $payload = new Payload;
+        $payload = $payload->withMessages([
+            'redirect' => '/',
+        ]);
+
+        $request = $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->getMock();
+        $response = new Response;
+
+        $response = call_user_func($this->responder, $request, $response, $payload);
+
+        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals('/', $response->getHeaderLine('Location'));
+
+        $payload = new Payload;
+        $payload = $payload->withMessages([
+            'status' => 301,
+            'redirect' => '/',
+        ]);
+
+        $response = call_user_func($this->responder, $request, $response, $payload);
+
+        $this->assertEquals(301, $response->getStatusCode());
+    }
+
+    public function testEmptyPayload()
+    {
+        $payload = new Payload;
+        $request = $this->getMockBuilder('Psr\Http\Message\ServerRequestInterface')->getMock();
+        $response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')->getMock();
+        $returned = call_user_func($this->responder, $request, $response, $payload);
+        $this->assertSame($returned, $response);
+    }
+}


### PR DESCRIPTION
Often an application will need to redirect the user from one location
to another. This makes it easy to do so by using Payload variables:

- `redirect` sets the URI to redirect to
- `status` optionally sets the HTTP code to use

Refs wheniwork/widgets#20