### PR TITLE
Don't reuse generic $e variable name in ExceptionHandler

### DIFF
--- a/src/Handler/ExceptionHandler.php
+++ b/src/Handler/ExceptionHandler.php
@@ -66,7 +66,7 @@ class ExceptionHandler
 
             try {
                 $response = $response->withStatus($e->getCode());
-            } catch (InvalidArgumentException $e) {
+            } catch (InvalidArgumentException $responseException) {
                 // Exception did not contain a valid code
                 $response = $response->withStatus(500);
             }


### PR DESCRIPTION
The catch block on line 69 overrides the $e variable which is then used to generate the response body (instead of the exception it was meant to represent).  Therefore any exception generated with a status code > 599 (like a PDOException 1045 for "access denied") is handled improperly.