### PR TITLE
Remove injector singleton

### DIFF
--- a/src/Configuration/AurynConfiguration.php
+++ b/src/Configuration/AurynConfiguration.php
@@ -11,11 +11,13 @@ class AurynConfiguration implements ConfigurationInterface
      */
     public function apply(Injector $injector)
     {
-        $injector->share($injector);
-
         $injector->alias(
             'Relay\ResolverInterface',
             'Spark\Resolver\AurynResolver'
         );
+
+        $injector->define('Spark\Resolver\AurynResolver', [
+            ':injector' => $injector,
+        ]);
     }
 }

--- a/tests/Configuration/AurynConfigurationTest.php
+++ b/tests/Configuration/AurynConfigurationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace SparkTests\Configuration;
+
+use Auryn\Injector;
+use Relay\ResolverInterface;
+use Spark\Configuration\AurynConfiguration;
+use Spark\Resolver\AurynResolver;
+
+class AurynConfigurationTest extends ConfigurationTestCase
+{
+    protected function getConfigurations()
+    {
+        return [
+            new AurynConfiguration,
+        ];
+    }
+
+    public function testApply()
+    {
+        $resolver = $this->injector->make(ResolverInterface::class);
+        $this->assertInstanceOf(AurynResolver::class, $resolver);
+
+        // Injector is not a singleton
+        $injector = $this->injector->make(Injector::class);
+        $this->assertNotSame($injector, $this->injector);
+    }
+}


### PR DESCRIPTION
Instead of having a single Auryn instance, explicitly set the resolver
parameter to the configured instance. This allows for separate
application instances. One possible use case is to have composite
responses as some sort of "batch" endpoint.