### PR TITLE
Skip plates tests when not available

### DIFF
--- a/tests/Configuration/PlatesResponderConfigurationTest.php
+++ b/tests/Configuration/PlatesResponderConfigurationTest.php
@@ -12,6 +12,10 @@ class PlatesResponderConfigurationTest extends ConfigurationTestCase
 {
     protected function getConfigurations()
     {
+        if (!class_exists('League\Plates\Engine')) {
+            $this->markTestSkipped('Plates is not installed');
+        }
+
         return [
             new AurynConfiguration,
             new NegotiationConfiguration,

--- a/tests/Formatter/PlatesFormatterTest.php
+++ b/tests/Formatter/PlatesFormatterTest.php
@@ -12,6 +12,10 @@ class PlatesFormatterTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        if (!class_exists('League\Plates\Engine')) {
+            $this->markTestSkipped('Plates is not installed');
+        }
+
         $this->templates = new Engine(__DIR__ . '/../_templates');
     }
 


### PR DESCRIPTION
Prevents complete failures when Plates is not installed. This can
happen when using global phpunit with a non-dev install.