### PR TITLE
Replace custom exception handler with whoops

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "php": ">=5.5.0",
         "arbiter/arbiter": "~0.1",
         "destrukt/destrukt": "^0.7",
+        "filp/whoops": "^1.1",
         "nikic/fast-route": "~0.6",
         "rdlowrey/auryn": "^1.1",
         "relay/relay": "^1.1",

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,6 +108,7 @@ The following configurations are typically used by default:
 * [`NegotiationConfiguration`](https://github.com/sparkphp/spark/blob/master/src/Configuration/NegotiationConfiguration.php) - Use [Negotiation](https://github.com/willdurand/negotiation) for [content negotiation](https://en.wikipedia.org/wiki/Content_negotiation)
 * [`PayloadConfiguration`](https://github.com/sparkphp/spark/blob/master/src/Configuration/PayloadConfiguration.php) - Use the default Spark class as the implementation for [`PayloadInterface`](https://github.com/sparkphp/adr/blob/master/src/PayloadInterface.php)
 * [`RelayConfiguration`](https://github.com/sparkphp/spark/blob/master/src/Configuration/RelayConfiguration.php) - Use [Relay](http://relayphp.com) for the framework middleware dispatcher
+* [`WhoopsConfiguration`](https://github.com/sparkphp/spark/blob/master/src/Configuration/WhoopsConfiguration.php) - Use [Whoops](http://filp.github.io/whoops/) for handling exceptions
 
 ### Optional Configurations
 
@@ -146,6 +147,7 @@ Spark\Application::build()
     Spark\Configuration\NegotiationConfiguration::class,
     Spark\Configuration\PayloadConfiguration::class,
     Spark\Configuration\RelayConfiguration::class,
+    Spark\Configuration\WhoopsConfiguration::class,
 ])
 ->setMiddleware([
     Relay\Middleware\ResponseSender::class,

--- a/src/Configuration/WhoopsConfiguration.php
+++ b/src/Configuration/WhoopsConfiguration.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Spark\Configuration;
+
+use Auryn\Injector;
+use Whoops\Run as Whoops;
+use Whoops\Handler\JsonResponseHandler;
+use Whoops\Handler\PlainTextHandler;
+
+class WhoopsConfiguration implements ConfigurationInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function apply(Injector $injector)
+    {
+        $injector->prepare(Whoops::class, [$this, 'prepareWhoops']);
+        $injector->prepare(JsonResponseHandler::class, [$this, 'prepareJsonHandler']);
+        $injector->prepare(PlainTextHandler::class, [$this, 'preparePlainTextHandler']);
+    }
+
+    /**
+     * @param Whoops $whoops
+     *
+     * @return void
+     */
+    public function prepareWhoops(Whoops $whoops)
+    {
+        set_error_handler([$whoops, Whoops::ERROR_HANDLER]);
+
+        $whoops->writeToOutput(false);
+        $whoops->allowQuit(false);
+    }
+
+    /**
+     * @param JsonResponseHandler $handler
+     *
+     * @return void
+     */
+    public function prepareJsonHandler(JsonResponseHandler $handler)
+    {
+        $handler->addTraceToOutput(true);
+    }
+
+    /**
+     * @param PlainTextHandler $handler
+     *
+     * @return void
+     */
+    public function preparePlainTextHandler(PlainTextHandler $handler)
+    {
+        $handler->outputOnlyIfCommandLine(false);
+    }
+}

--- a/src/Handler/ExceptionHandlerPreferences.php
+++ b/src/Handler/ExceptionHandlerPreferences.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spark\Handler;
+
+use Destrukt\Dictionary;
+use Whoops\Handler\JsonResponseHandler;
+use Whoops\Handler\PlainTextHandler;
+use Whoops\Handler\PrettyPageHandler;
+use Whoops\Handler\XmlResponseHandler;
+
+class ExceptionHandlerPreferences extends Dictionary
+{
+    /**
+     * @inheritDoc
+     */
+    public function __construct(array $data = [])
+    {
+        $data += [
+            'text/html' => PrettyPageHandler::class,
+            'application/javascript' => JsonResponseHandler::class,
+            'application/json' => JsonResponseHandler::class,
+            'applicaiton/ld+json' => JsonResponseHandler::class,
+            'application/vnd.api+json' => JsonResponseHandler::class,
+            'application/vnd.geo+json' => JsonResponseHandler::class,
+            'application/xml' => XmlResponseHandler::class,
+            'application/atom+xml' => XmlResponseHandler::class,
+            'application/rss+xml' => XmlResponseHandler::class,
+            'text/plain' => PlainTextHandler::class,
+        ]; // @codeCoverageIgnore
+
+        parent::__construct($data);
+    }
+}

--- a/tests/Handler/ExceptionHandlerPreferencesTest.php
+++ b/tests/Handler/ExceptionHandlerPreferencesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace SparkTests\Handler;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use Spark\Handler\ExceptionHandlerPreferences;
+use Whoops\Handler\JsonResponseHandler;
+use Whoops\Handler\PlainTextHandler;
+use Whoops\Handler\PrettyPageHandler;
+use Whoops\Handler\SoapHandler;
+use Whoops\Handler\XmlResponseHandler;
+
+class ExceptionHandlerPreferencesTest extends TestCase
+{
+    public function testConstruct()
+    {
+        $prefs = new ExceptionHandlerPreferences;
+
+        $this->assertNotContains(SoapHandler::class, $prefs);
+
+        $expected = [
+            PrettyPageHandler::class,
+            JsonResponseHandler::class,
+            XmlResponseHandler::class,
+            PlainTextHandler::class,
+        ];
+
+        foreach ($expected as $handler) {
+            $this->assertContains($handler, $prefs);
+        }
+
+        $types = [
+            'text/html',
+            'application/javascript',
+            'application/json',
+            'applicaiton/ld+json',
+            'application/vnd.api+json',
+            'application/vnd.geo+json',
+            'application/xml',
+            'application/atom+xml',
+            'application/rss+xml',
+            'text/plain',
+        ];
+
+        foreach ($types as $type) {
+            $this->assertArrayHasKey($type, $prefs);
+        }
+    }
+}


### PR DESCRIPTION
Having a content negotiated exception handler provides more robust
debugging capabilities in multiple contexts. [Whoops][1] has the added
benefit of being capable of logging.

By having a separate class for the preferred handlers the user can
customize which handlers will be used easily.

[1]: https://github.com/filp/whoops

Fixes #89