### PR TITLE
Fix bugs in detectEnvFile()

### DIFF
--- a/src/Configuration/EnvConfiguration.php
+++ b/src/Configuration/EnvConfiguration.php
@@ -66,7 +66,11 @@ class EnvConfiguration implements ConfigurationInterface
             if (is_file($dir . $env)) {
                 return $dir . $env;
             }
-        } while (($dir = dirname($dir)) && is_readable($dir));
+        } while (
+            $dir != dirname($dir) &&
+            ($dir = dirname($dir)) &&
+            is_readable($dir)
+        );
 
         throw EnvException::detectionFailed();
     }

--- a/src/Configuration/EnvConfiguration.php
+++ b/src/Configuration/EnvConfiguration.php
@@ -66,7 +66,7 @@ class EnvConfiguration implements ConfigurationInterface
             if (is_file($dir . $env)) {
                 return $dir . $env;
             }
-        } while ($dir = dirname($dir) && is_readable($dir));
+        } while (($dir = dirname($dir)) && is_readable($dir));
 
         throw EnvException::detectionFailed();
     }

--- a/src/Configuration/EnvConfiguration.php
+++ b/src/Configuration/EnvConfiguration.php
@@ -66,11 +66,8 @@ class EnvConfiguration implements ConfigurationInterface
             if (is_file($dir . $env)) {
                 return $dir . $env;
             }
-        } while (
-            $dir != dirname($dir) &&
-            ($dir = dirname($dir)) &&
-            is_readable($dir)
-        );
+            $dir = dirname($dir);
+        } while (is_readable($dir) && dirname($dir) !== $dir);
 
         throw EnvException::detectionFailed();
     }

--- a/tests/Configuration/EnvConfigurationTest.php
+++ b/tests/Configuration/EnvConfigurationTest.php
@@ -18,7 +18,7 @@ class EnvConfigurationTest extends ConfigurationTestCase
             $this->markTestSkipped('Dotenv is not installed');
         }
 
-        $this->envfile = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR . '.env';
+        $this->envfile = dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR . '.env';
     }
 
     protected function getConfigurations()


### PR DESCRIPTION
The `&&` operator has a higher precedence than the `=` operator, so $dir was actually getting set to 1.