### PR TITLE
Allow objects to be in used in configuration sets

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,7 @@ In Spark, configuration of the injector is encapsulated in classes implementing 
 
 To facilitate ease of reuse for groupings of configuration, Spark provides a [`ConfigurationSet`](https://github.com/sparkphp/spark/blob/master/src/Configuration/ConfigurationSet.php) class, which takes in a list of configuration classes and applies them to an injector instance.
 
-For a Spark application to function properly, the `Injector` instance it uses will need some configuration. This configuration is defined using the [`Application`](https://github.com/sparkphp/spark/blob/master/src/Application.php) `setConfiguration()` method, which accepts an array of configuration classes to be applied. It is also possible to provide a `ConfigurationSet` when calling `Application::build()` to be used as the default set.
+For a Spark application to function properly, the `Injector` instance it uses will need some configuration. This configuration is defined using the [`Application`](https://github.com/sparkphp/spark/blob/master/src/Application.php) `setConfiguration()` method, which accepts an array of configuration classes or objects to be applied. It is also possible to provide a `ConfigurationSet` when calling `Application::build()` to be used as the default set.
 
 ### Default Configuration
 
@@ -115,6 +115,21 @@ The following configurations are available but not used by default:
 
 * [`EnvConfiguration`](https://github.com/sparkphp/spark/blob/master/src/Configuration/EnvConfiguration.php) - Use [Dotenv](https://github.com/josegonzalez/php-dotenv) to populate the content of [`Env`](https://github.com/sparkphp/spark/blob/master/src/Env.php)
 * [`PlatesResponderConfiguration`](https://github.com/sparkphp/spark/blob/master/src/Configuration/PlatesResponderConfiguration.php) - Use [Plates](http://platesphp.com/) as the default [responder](#responders)
+
+#### Setting The Env File
+
+When using `EnvConfiguration` it may be desirable to define the path to the `.env` file if it is outside of your project root or simply to avoid automatic detection. This can be done by providing a constructed instance of the `EnvConfiguration` during bootstrapping:
+
+```php
+Spark\Application::build()
+->setConfiguration([
+    new Spark\Configuration\EnvConfiguration('path/to/.env'),
+    // ...
+])
+// ...
+```
+
+*See the [bootstrap](#bootstrap) section for more details.*
 
 ### Env Configuration
 

--- a/src/Configuration/ConfigurationSet.php
+++ b/src/Configuration/ConfigurationSet.php
@@ -29,8 +29,10 @@ class ConfigurationSet extends Set implements ConfigurationInterface
      */
     public function apply(Injector $injector)
     {
-        foreach ($this as $class) {
-            $configuration = $injector->make($class);
+        foreach ($this as $configuration) {
+            if (!is_object($configuration)) {
+                $configuration = $injector->make($configuration);
+            }
             $configuration->apply($injector);
         }
     }

--- a/tests/Configuration/ConfigurationSetTest.php
+++ b/tests/Configuration/ConfigurationSetTest.php
@@ -32,6 +32,23 @@ class ConfigurationSetTest extends TestCase
         $set->apply($injector);
     }
 
+    public function testSetObject()
+    {
+        $config = $this->getMock(ConfigurationInterface::class);
+        $injector = $this->getMock(Injector::class);
+
+        $config
+            ->expects($this->once())
+            ->method('apply')
+            ->with($injector);
+
+        $set = new ConfigurationSet([
+            $config,
+        ]);
+
+        $set->apply($injector);
+    }
+
     /**
      * @expectedException Spark\Exception\ConfigurationException
      * @expectedExceptionRegExp /class .* must implement ConfigurationInterface/i


### PR DESCRIPTION
Sometimes it is more convenient to pass a fully constructed object than
to use a specification only. For example, when using `EnvConfiguration`
a user might want to define the file path directly in the boostrap.

Refs #101