### PR TITLE
Improve input handling of parsed bodies

### DIFF
--- a/src/Input.php
+++ b/src/Input.php
@@ -17,24 +17,28 @@ class Input implements InputInterface
     public function __invoke(
         ServerRequestInterface $request
     ) {
-        $input = [];
+        $attrs = $request->getAttributes();
+        $body = $request->getParsedBody();
+        $cookies = $request->getCookieParams();
+        $query = $request->getQueryParams();
+        $uploads = $request->getUploadedFiles();
 
-        if ($params = $request->getQueryParams()) {
-            $input = array_replace($input, $params);
-        }
-        if ($params = $request->getParsedBody()) {
-            $input = array_replace($input, $params);
-        }
-        if ($params = $request->getUploadedFiles()) {
-            $input = array_replace($input, $params);
-        }
-        if ($params = $request->getCookieParams()) {
-            $input = array_replace($input, $params);
-        }
-        if ($params = $request->getAttributes()) {
-            $input = array_replace($input, $params);
+        if (empty($body)) {
+            $body = [];
+        } elseif (is_object($body)) {
+            // Because the parsed body may also be represented as an object,
+            // additional parsing is required. This is a bit dirty but works
+            // very well for anonymous objects.
+            $body = json_decode(json_encode($body), true);
         }
 
-        return $input;
+        // Order matters here! Important values go last!
+        return array_replace(
+            $query,
+            $body,
+            $uploads,
+            $cookies,
+            $attrs
+        );
     }
 }

--- a/tests/InputTest.php
+++ b/tests/InputTest.php
@@ -27,17 +27,41 @@ class InputTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($query, $found);
     }
 
-    public function testParsedBody()
+    public function dataParsedBody()
     {
+        $data = [];
+
+        // Null body should be an empty array
+        $body = null;
+        $expected = [];
+        $data[] = [$expected, $body];
+
+        // Array body should remain the same
         $body = [
             'body' => 'parsed',
+            'has' => [
+                'other' => 'values',
+            ],
         ];
+        $expected = $body;
+        $data[] = [$expected, $body];
 
+        // Object body should be converted to an array
+        $body = json_decode(json_encode($body));
+        $data[] = [$expected, $body];
+
+        return $data;
+    }
+    /**
+     * @dataProvider dataParsedBody
+     */
+    public function testParsedBody($expected, $body)
+    {
         $request = new ServerRequest;
         $request = $request->withParsedBody($body);
 
-        $found = $this->execute($request);
-        $this->assertSame($body, $found);
+        $input = $this->execute($request);
+        $this->assertSame($expected, $input);
     }
 
     public function testUploadedFiles()


### PR DESCRIPTION
According to [PSR-7 spec][1] the parsed body of a request may return an
object or array or null. Handle all of these cases properly.

Also improves how the input array is generated by using a single
`array_replace` call.

[1]: http://www.php-fig.org/psr/psr-7/#3-2-1-psr-http-message-serverrequestinterface