### PR TITLE
Clean up action and dispatch handler

### DIFF
--- a/src/Handler/DispatchHandler.php
+++ b/src/Handler/DispatchHandler.php
@@ -9,14 +9,10 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Spark\Directory;
 use Spark\Exception\HttpException;
+use Spark\Handler\ActionHandler;
 
 class DispatchHandler
 {
-    /**
-     * @var string
-     */
-    protected $actionAttribute = 'spark/adr:action';
-
     /**
      * @var Director
      */
@@ -47,7 +43,7 @@ class DispatchHandler
             $request->getUri()->getPath()
         );
 
-        $request = $request->withAttribute($this->actionAttribute, $action);
+        $request = $request->withAttribute(ActionHandler::ACTION_ATTRIBUTE, $action);
 
         foreach ($args as $key => $value) {
             $request = $request->withAttribute($key, $value);

--- a/tests/Fake/FakeDomain.php
+++ b/tests/Fake/FakeDomain.php
@@ -9,10 +9,8 @@ class FakeDomain implements DomainInterface
 
     public function __invoke(array $input)
     {
-        unset($input['spark/adr:route']);
         return (new Payload())
             ->withStatus(Payload::OK)
             ->withOutput(['success' => true, 'input' => $input]);
     }
-
 }

--- a/tests/Handler/DispatchHandlerTest.php
+++ b/tests/Handler/DispatchHandlerTest.php
@@ -3,8 +3,8 @@
 namespace SparkTests\Handler;
 
 use SparkTests\DirectoryTestCase;
-use Spark\Adr\DomainInterface;
 use Spark\Directory;
+use Spark\Handler\ActionHandler;
 use Spark\Handler\DispatchHandler;
 use Zend\Diactoros\Uri;
 use Zend\Diactoros\Response;
@@ -30,7 +30,7 @@ class DispatchHandlerTest extends DirectoryTestCase
         $response = new Response;
 
         $next = function (ServerRequest $request, Response $response) use ($action) {
-            $this->assertSame($action, $request->getAttribute('spark/adr:action'));
+            $this->assertSame($action, $request->getAttribute(ActionHandler::ACTION_ATTRIBUTE));
             $this->assertSame('tester', $request->getAttribute('name'));
             return $response;
         };


### PR DESCRIPTION
The action handler was not actually using any of the Arbiter methods,
except for the resolver. Stop extending it and clean methods and docs.

Also reduces repetition by using a constant for the action attribute
that is shared between the action and dispatch handlers.