### PR TITLE
Clean up content handlers

### DIFF
--- a/src/Handler/ContentHandler.php
+++ b/src/Handler/ContentHandler.php
@@ -1,33 +1,41 @@
 <?php
 namespace Spark\Handler;
 
-use Psr\Http\Message\ResponseInterface as Response;
-use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
 abstract class ContentHandler
 {
     /**
-     * Parses request bodies based on content type
+     * Parses request bodies based on content type.
      *
-     * @param  Request  $request
-     * @param  Response $response
-     * @param  callable $next
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @param callable $next
+     *
      * @return Response
      */
-    public function __invoke(Request $request, Response $response, callable $next)
-    {
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        callable $next
+    ) {
         $mime = strtolower($request->getHeaderLine('Content-Type'));
+
         if ($this->isApplicableMimeType($mime) && !$request->getParsedBody()) {
-            $parsed = $this->getParsedBody((string) $request->getBody());
+            $body = (string) $request->getBody();
+            $parsed = $this->getParsedBody($body);
             $request = $request->withParsedBody($parsed);
         }
+
         return $next($request, $response);
     }
 
     /**
      * Check if the content type is appropriate for handling.
      *
-     * @param  string $mime
+     * @param string $mime
+     *
      * @return boolean
      */
     abstract protected function isApplicableMimeType($mime);
@@ -36,6 +44,7 @@ abstract class ContentHandler
      * Parse the request body.
      *
      * @param string $body
+     *
      * @return mixed
      */
     abstract protected function getParsedBody($body);

--- a/src/Handler/FormContentHandler.php
+++ b/src/Handler/FormContentHandler.php
@@ -8,7 +8,7 @@ class FormContentHandler extends ContentHandler
      */
     protected function isApplicableMimeType($mime)
     {
-        return 'application/x-www-form-urlencoded' === $mime;
+        return $mime === 'application/x-www-form-urlencoded';
     }
 
     /**

--- a/src/Handler/JsonContentHandler.php
+++ b/src/Handler/JsonContentHandler.php
@@ -1,10 +1,7 @@
 <?php
 namespace Spark\Handler;
 
-use Psr\Http\Message\ResponseInterface as Response;
-use Psr\Http\Message\ServerRequestInterface as Request;
 use Spark\Exception\HttpException;
-use Zend\Diactoros\Stream;
 
 class JsonContentHandler extends ContentHandler
 {
@@ -13,8 +10,7 @@ class JsonContentHandler extends ContentHandler
      */
     protected function isApplicableMimeType($mime)
     {
-        return 'application/json' === $mime
-            || 'application/vnd.api+json' === $mime;
+        return preg_match('~^application/([a-z.]+\+)?json$~', $mime);
     }
 
     /**
@@ -23,10 +19,12 @@ class JsonContentHandler extends ContentHandler
     protected function getParsedBody($body)
     {
         $body = json_decode($body, true);
-        if (json_last_error() !== \JSON_ERROR_NONE) {
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
             $message = 'JSON ' . json_last_error_msg();
             throw HttpException::badRequest($message);
         }
+
         return $body;
     }
 }

--- a/tests/Handler/ContentHandlerTestCase.php
+++ b/tests/Handler/ContentHandlerTestCase.php
@@ -7,7 +7,7 @@ use Zend\Diactoros\Stream;
 
 abstract class ContentHandlerTestCase extends TestCase
 {
-    /** 
+    /**
      * @param string $mime
      * @param string $body
      * @return ServerRequest


### PR DESCRIPTION
Some simple changes to improve the content handler style and function:

- remove yoda conditions
- allow any `application/*json` content type
- remove interface aliases
- normalize whitespace