### PR TITLE
Make chained and formatted responders into sets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.5.0",
         "arbiter/arbiter": "^0.1",
-        "destrukt/destrukt": "^0.7",
+        "destrukt/destrukt": "^0.7.1",
         "filp/whoops": "^1.1",
         "nikic/fast-route": "^0.7",
         "rdlowrey/auryn": "^1.1",

--- a/docs/index.md
+++ b/docs/index.md
@@ -417,18 +417,20 @@ Spark provides a few native responder implementations.
 
 ### Chained Responder
 
-[`ChainedResponder`](https://github.com/sparkphp/spark/blob/master/src/Responder/ChainedResponder.php) is the default responder which allows multiple responders to be applied to the same response instance. This is intended to allow for [separation of concerns](https://en.wikipedia.org/wiki/Separation_of_concerns) in configuring different areas of the response.
+[`ChainedResponder`](https://github.com/sparkphp/spark/blob/master/src/Responder/ChainedResponder.php) is the default responder which allows multiple responders to be applied to the same response instance. This is intended to allow for [separation of concerns](https://en.wikipedia.org/wiki/Separation_of_concerns) in configuring different areas of the response. The `ChainedResponder` extends [`Destrukt\Set`](https://github.com/destruktphp/destrukt/blob/master/src/Set.php).
 
-By default, [`ChainedResponder`](https://github.com/sparkphp/spark/blob/master/src/Responder/ChainedResponder.php) includes [all the default responders](https://github.com/sparkphp/spark/blob/master/src/Responder). Responders can be added using its `withAddedResponder()` method or overwritten entirely using its `withResponders()` method.
+By default [`ChainedResponder`](https://github.com/sparkphp/spark/blob/master/src/Responder/ChainedResponder.php) includes [all the default responders](https://github.com/sparkphp/spark/blob/master/src/Responder). Responders can be added using its `withValue()` method or overwritten entirely using its `withData()` method.
 
 ### Formatted Responder
 
-[`FormattedResponder`](https://github.com/sparkphp/spark/blob/master/src/Responder/FormattedResponder.php) uses the [Negotiation](https://github.com/willdurand/negotiation) library to support [content negotiation](https://en.wikipedia.org/wiki/Content_negotiation). When a desirable format has been founded, it uses an appropriate implementation of [`AbstractFormatter`](https://github.com/sparkphp/spark/blob/master/src/Formatter/AbstractFormatter.php) to encode the payload data and return it as a string.
+[`FormattedResponder`](https://github.com/sparkphp/spark/blob/master/src/Responder/FormattedResponder.php) uses the [Negotiation](https://github.com/willdurand/negotiation) library to support [content negotiation](https://en.wikipedia.org/wiki/Content_negotiation). When a desirable format has been founded, it uses an appropriate implementation of [`AbstractFormatter`](https://github.com/sparkphp/spark/blob/master/src/Formatter/AbstractFormatter.php) to encode the payload data and return it as a string. The `FormattedResponder` extends [`Destrukt\Dictionary`](https://github.com/destruktphp/destrukt/blob/master/src/Dictionary.php).
 
-Here are the formatter implementations that are natively supported.
+Here are the formatter implementations that are natively supported:
 
 * [`JsonFormatter`](https://github.com/sparkphp/spark/blob/master/src/Formatter/JsonFormatter.php) - Encodes the payload as [JSON](http://www.json.org/)
 * [`PlatesFormatter`](https://github.com/sparkphp/spark/blob/master/src/Formatter/PlatesFormatter.php) - Applies the payload data to a [Plates](http://platesphp.com/) template specified in the payload and returns the result
+
+By default [`FormattedResponder`](https://github.com/sparkphp/spark/blob/master/src/Responder/FormattedResponder.php) includes `JsonFormatter`. Responders can be added using its `withValue()` method or overwritten entirely using its `withData()` method.
 
 ### Redirect
 

--- a/src/Configuration/PlatesResponderConfiguration.php
+++ b/src/Configuration/PlatesResponderConfiguration.php
@@ -11,9 +11,7 @@ class PlatesResponderConfiguration implements ConfigurationInterface
     public function apply(Injector $injector)
     {
         $injector->prepare(FormattedResponder::class, function (FormattedResponder $responder) {
-            return $responder->withFormatters([
-                PlatesFormatter::class => 1.0,
-            ]);
+            return $responder->withValue(PlatesFormatter::class, 1.0);
         });
     }
 }

--- a/src/Resolver/ResolverTrait.php
+++ b/src/Resolver/ResolverTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spark\Resolver;
+
+trait ResolverTrait
+{
+    /**
+     * @var \Relay\ResolverInterface
+     */
+    private $resolver;
+
+    /**
+     * Resolve a class spec into an object, if it is not already instantiated.
+     *
+     * @param string|object $specOrObject
+     *
+     * @return object
+     */
+    private function resolve($specOrObject)
+    {
+        if (is_object($specOrObject)) {
+            return $specOrObject;
+        }
+
+        return call_user_func($this->resolver, $specOrObject);
+    }
+}

--- a/tests/Configuration/PlatesResponderConfigurationTest.php
+++ b/tests/Configuration/PlatesResponderConfigurationTest.php
@@ -24,9 +24,8 @@ class PlatesResponderConfigurationTest extends ConfigurationTestCase
     public function testApply()
     {
         $responder = $this->injector->make(FormattedResponder::class);
-        $formatters = $responder->getFormatters();
 
-        $this->assertArrayHasKey(PlatesFormatter::class, $formatters);
-        $this->assertSame(1.0, $formatters[PlatesFormatter::class]);
+        $this->assertArrayHasKey(PlatesFormatter::class, $responder);
+        $this->assertSame(1.0, $responder[PlatesFormatter::class]);
     }
 }


### PR DESCRIPTION
By converting these responders into a set and a dictionary validation
is automatically handled and modification becomes easier.

Also adds a `ResolverTrait` to DRY usage of the resolver.